### PR TITLE
v0.19.0-beta

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -1,0 +1,451 @@
+/**
+ * Account Page - Sync Control and Account Management
+ *
+ * The full view of a connected account: what is linked, whether the two ends
+ * agree, and every lever for forcing the issue. Sync is bookkeeping, so the
+ * page is built as a ledger — monospace, tabular, one fact per row — with the
+ * device↔cloud rail as the only large element, because that is the one thing
+ * worth seeing from across the room.
+ *
+ * Signed out, the page collapses to a single offer rather than an empty state.
+ *
+ * @fileoverview Account connection, sync status, and data controls.
+ * @author BIT Focus Development Team
+ * @since v0.19.0
+ */
+
+"use client";
+
+import { useEffect, useState, type JSX, type ReactNode } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/hooks/useAuth";
+import { useSync } from "@/hooks/useSync";
+import { useConfig } from "@/hooks/useConfig";
+import SyncManager from "@/lib/SyncManager";
+import { PROVIDER_LABELS } from "@/lib/pocketbase";
+import AccountAvatar from "@/components/auth/AccountAvatar";
+import SyncRail, {
+  formatSyncTime,
+  syncStatusLabel,
+} from "@/components/auth/SyncRail";
+import ProviderButtons from "@/components/auth/ProviderButtons";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { toast } from "sonner";
+import {
+  FaArrowsRotate,
+  FaCloudArrowDown,
+  FaCloudArrowUp,
+  FaRightFromBracket,
+  FaTriangleExclamation,
+} from "react-icons/fa6";
+
+// ── Primitives ───────────────────────────────────────────────────────────────
+
+/** One ledger row: an uppercase label against a monospace value. */
+function Row({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}): JSX.Element {
+  return (
+    <div className="flex items-center justify-between gap-4 px-4 py-3">
+      <span className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground shrink-0">
+        {label}
+      </span>
+      <span className="font-mono text-sm tabular-nums text-right truncate">
+        {children}
+      </span>
+    </div>
+  );
+}
+
+/** Section heading in the app's eyebrow register. */
+function SectionTitle({ children }: { children: ReactNode }): JSX.Element {
+  return (
+    <h2 className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
+      {children}
+    </h2>
+  );
+}
+
+/**
+ * Confirmation dialog for an action that replaces data.
+ *
+ * Forced pushes and pulls are one-way doors, so each states plainly what is
+ * about to be overwritten before it happens.
+ */
+function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel,
+  destructive,
+  onConfirm,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  destructive?: boolean;
+  onConfirm: () => void | Promise<void>;
+}): JSX.Element {
+  const [working, setWorking] = useState(false);
+  return (
+    <Dialog open={open} onOpenChange={(o) => !working && onOpenChange(o)}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription className="leading-relaxed">
+            {description}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            variant="ghost"
+            disabled={working}
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant={destructive ? "destructive" : "default"}
+            disabled={working}
+            onClick={async () => {
+              setWorking(true);
+              await onConfirm();
+              setWorking(false);
+              onOpenChange(false);
+            }}
+          >
+            {working ? "Working…" : confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Page ─────────────────────────────────────────────────────────────────────
+
+export default function AccountPage(): JSX.Element {
+  const router = useRouter();
+  const { user, ready, signOut, deleteAccount } = useAuth();
+  const {
+    status,
+    direction,
+    dirty,
+    revision,
+    syncedAt,
+    lastWriter,
+    auto,
+    error,
+    syncNow,
+    forcePush,
+    forcePull,
+    setAuto,
+    deleteCloudCopy,
+  } = useSync();
+  const { name } = useConfig();
+
+  const [confirm, setConfirm] = useState<
+    "push" | "pull" | "wipe" | "delete" | null
+  >(null);
+
+  // Keeps the "synced 3 min ago" line honest without a subscription.
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 30_000);
+    return () => clearInterval(id);
+  }, []);
+
+  // ── Signed out ───────────────────────────────────────────────────────────
+
+  if (!ready || !user) {
+    return (
+      <div className="flex-1 flex flex-col">
+        <div className="max-w-lg mx-auto w-full px-6 py-16 flex flex-col gap-6">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-widest text-primary">
+              Account
+            </p>
+            <h1 className="mt-2 text-3xl font-semibold tracking-tight">
+              One account, every device.
+            </h1>
+            <p className="mt-3 text-muted-foreground leading-relaxed">
+              BIT Focus works fine without this. Connect an account only when
+              you want the same sessions, projects, and rewards on more than one
+              device.
+            </p>
+          </div>
+
+          <SyncRail status="off" direction={null} dirty={false} />
+
+          <ProviderButtons />
+        </div>
+      </div>
+    );
+  }
+
+  // ── Connected ────────────────────────────────────────────────────────────
+
+  const busy = status === "busy";
+  const provider = PROVIDER_LABELS[user.provider] ?? user.provider ?? "—";
+
+  return (
+    <div className="flex-1 flex flex-col">
+      <div className="max-w-screen-md mx-auto w-full px-6 py-6 flex flex-col gap-6">
+        {/* ── Identity ─────────────────────────────────────────────────── */}
+        <div className="flex items-center gap-4">
+          <AccountAvatar seed={name} className="size-14 border shrink-0" />
+          <div className="min-w-0">
+            <p className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
+              Account
+            </p>
+            <h1 className="text-2xl font-semibold tracking-tight truncate">
+              {user.name || "Your account"}
+            </h1>
+            <p className="text-sm text-muted-foreground truncate">
+              {user.email}
+            </p>
+          </div>
+        </div>
+
+        {/* ── The link ─────────────────────────────────────────────────── */}
+        <section className="rounded-xl border bg-card p-5 flex flex-col gap-4">
+          <SyncRail
+            status={status}
+            direction={direction}
+            dirty={dirty}
+            className="px-1"
+          />
+
+          <div className="flex items-baseline justify-between gap-3">
+            <span className="text-[11px] uppercase tracking-widest text-muted-foreground truncate">
+              {SyncManager.deviceLabel()}
+            </span>
+            <span
+              className={cn(
+                "text-sm font-medium tracking-tight text-center",
+                status === "error" || status === "conflict"
+                  ? "text-destructive"
+                  : "text-foreground",
+              )}
+            >
+              {syncStatusLabel(status, direction, dirty, syncedAt)}
+            </span>
+            <span className="text-[11px] uppercase tracking-widest text-muted-foreground truncate">
+              Cloud
+            </span>
+          </div>
+
+          {error && (
+            <p className="text-xs text-destructive leading-relaxed">{error}</p>
+          )}
+
+          <div className="flex flex-wrap gap-2">
+            <Button
+              size="sm"
+              disabled={busy}
+              onClick={() => syncNow()}
+              className="gap-2"
+            >
+              <FaArrowsRotate
+                className={cn("size-3", busy && "motion-safe:animate-spin")}
+              />
+              Sync now
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={busy}
+              onClick={() => setConfirm("push")}
+              className="gap-2"
+            >
+              <FaCloudArrowUp className="size-3" />
+              Upload this device
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={busy}
+              onClick={() => setConfirm("pull")}
+              className="gap-2"
+            >
+              <FaCloudArrowDown className="size-3" />
+              Download from cloud
+            </Button>
+          </div>
+        </section>
+
+        {/* ── Ledger ───────────────────────────────────────────────────── */}
+        <section className="flex flex-col gap-2">
+          <SectionTitle>Sync record</SectionTitle>
+          <div className="rounded-xl border bg-card divide-y">
+            <Row label="Last sync">{formatSyncTime(syncedAt)}</Row>
+            <Row label="Revision">{revision}</Row>
+            <Row label="Last written by">{lastWriter ?? "—"}</Row>
+            <Row label="This device">{SyncManager.deviceLabel()}</Row>
+            <Row label="Signed in with">{provider}</Row>
+            <Row label="Pending changes">{dirty ? "Yes" : "None"}</Row>
+          </div>
+        </section>
+
+        {/* ── Preferences ──────────────────────────────────────────────── */}
+        <section className="flex flex-col gap-2">
+          <SectionTitle>Behaviour</SectionTitle>
+          <div className="rounded-xl border bg-card px-4 py-3.5 flex items-center justify-between gap-4">
+            <div className="flex flex-col gap-0.5">
+              <Label htmlFor="auto-sync" className="text-sm cursor-pointer">
+                Sync in the background
+              </Label>
+              <span className="text-xs text-muted-foreground">
+                Send changes as you make them and take updates from your other
+                devices.
+              </span>
+            </div>
+            <Switch id="auto-sync" checked={auto} onCheckedChange={setAuto} />
+          </div>
+        </section>
+
+        {/* ── Leaving ──────────────────────────────────────────────────── */}
+        <section className="flex flex-col gap-2">
+          <SectionTitle>Leaving</SectionTitle>
+          <div className="rounded-xl border bg-card divide-y">
+            <div className="flex items-center justify-between gap-4 px-4 py-3.5">
+              <div className="flex flex-col gap-0.5 min-w-0">
+                <p className="text-sm font-medium">Sign out</p>
+                <p className="text-xs text-muted-foreground">
+                  Disconnects this device. Your data stays here.
+                </p>
+              </div>
+              <Button
+                size="sm"
+                variant="outline"
+                className="gap-2 shrink-0"
+                onClick={() => {
+                  signOut();
+                  toast("Signed out. Your data stays on this device.");
+                  router.push("/");
+                }}
+              >
+                <FaRightFromBracket className="size-3" />
+                Sign out
+              </Button>
+            </div>
+
+            <div className="flex items-center justify-between gap-4 px-4 py-3.5">
+              <div className="flex flex-col gap-0.5 min-w-0">
+                <p className="text-sm font-medium">Delete the cloud copy</p>
+                <p className="text-xs text-muted-foreground">
+                  Clears what is stored on the server. This device keeps
+                  everything.
+                </p>
+              </div>
+              <Button
+                size="sm"
+                variant="outline"
+                className="shrink-0"
+                onClick={() => setConfirm("wipe")}
+              >
+                Delete copy
+              </Button>
+            </div>
+
+            <div className="flex items-center justify-between gap-4 px-4 py-3.5">
+              <div className="flex flex-col gap-0.5 min-w-0">
+                <p className="text-sm font-medium text-destructive">
+                  Delete account
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Removes the account and its cloud copy for good. This device
+                  keeps everything.
+                </p>
+              </div>
+              <Button
+                size="sm"
+                variant="destructive"
+                className="gap-2 shrink-0"
+                onClick={() => setConfirm("delete")}
+              >
+                <FaTriangleExclamation className="size-3" />
+                Delete
+              </Button>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      {/* ── Confirmations ──────────────────────────────────────────────── */}
+
+      <ConfirmDialog
+        open={confirm === "push"}
+        onOpenChange={(o) => setConfirm(o ? "push" : null)}
+        title="Upload this device?"
+        description="The cloud copy is replaced with what is on this device. Your other devices will match it the next time they sync."
+        confirmLabel="Upload"
+        onConfirm={async () => {
+          await forcePush();
+          toast.success("Uploaded.");
+        }}
+      />
+
+      <ConfirmDialog
+        open={confirm === "pull"}
+        onOpenChange={(o) => setConfirm(o ? "pull" : null)}
+        title="Download from the cloud?"
+        description="This device is replaced with the cloud copy and the app reloads. Anything changed here since the last sync is lost."
+        confirmLabel="Download"
+        destructive
+        onConfirm={async () => {
+          await forcePull();
+        }}
+      />
+
+      <ConfirmDialog
+        open={confirm === "wipe"}
+        onOpenChange={(o) => setConfirm(o ? "wipe" : null)}
+        title="Delete the cloud copy?"
+        description="The server copy is removed. This device keeps all of its data, and the next sync uploads it again."
+        confirmLabel="Delete copy"
+        destructive
+        onConfirm={async () => {
+          await deleteCloudCopy();
+          toast("Cloud copy deleted.");
+        }}
+      />
+
+      <ConfirmDialog
+        open={confirm === "delete"}
+        onOpenChange={(o) => setConfirm(o ? "delete" : null)}
+        title="Delete your account?"
+        description="Your account and its cloud copy are permanently removed, and every signed-in device is disconnected. The data on this device is untouched."
+        confirmLabel="Delete account"
+        destructive
+        onConfirm={async () => {
+          try {
+            await deleteAccount();
+            toast("Account deleted. Your data stays on this device.");
+            router.push("/");
+          } catch {
+            toast.error("Could not delete the account. Try again.");
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/app/changelog/CHANGELOG.ts
+++ b/app/changelog/CHANGELOG.ts
@@ -1,6 +1,23 @@
-export const VERSION = "v0.18.12 (LTS)";
+export const VERSION = "v0.19.0-beta";
 
 const CHANGELOG = `
+
+## \`v0.19.0-beta\` (2026-07-24) — Accounts & Cross-Device Sync
+- Added: Optional accounts. BIT Focus stays local-first — every feature works signed out, and connecting an account is entirely opt-in.
+- Added: Sign in with Google (soon), Discord, or GitHub. There is no email/password path; providers are read live from the server, so a button only appears for a provider that actually works.
+- Added: Full two-way sync of everything — focus sessions, tags, projects, milestones, issues, rewards, discounts, notes, drawings, AI chats, timeblocks, and settings.
+- Added: New \`/account\` page with the sync ledger (last sync, revision, last writing device, pending changes), manual upload/download, a background-sync toggle, and account removal.
+- Added: Account section at the top of the Profile dropdown, showing who is connected, whether data is current, and a "Sync now" button.
+- Added: Account step in Onboarding — sign in on a fresh device and your existing data is restored before you fill anything in.
+- Added: Sync indicator in the Top Bar that shows sync state at a glance and syncs on click.
+- Added: "Sync rail" indicator — a device↔cloud link whose travelling marker moves right when uploading and left when downloading, and visibly breaks when the two ends disagree.
+- Added: Conflict resolution dialog. When this device and the cloud both changed, sync stops and asks, comparing what each version holds (sessions, projects, notes, timeblocks, drawings, chats, size) instead of silently overwriting one.
+- Added: Auto-sync triggers — 4s after your last change, a 60s heartbeat, instantly when another device writes (realtime), when the tab regains focus, and on page close.
+- Added: New \`lib/pocketbase.ts\`, \`lib/SyncManager.ts\`, \`hooks/useAuth.ts\`, and \`hooks/useSync.ts\`.
+- Added: Calendar timeblocks are now included in export, import, and sync — they were previously missing from \`.bitf.json\` backups.
+- Fixed: Importing a \`.bitf.json\` backup no longer signs you out; session and sync keys are preserved across a restore.
+- Security: Session tokens are never written into exports or cloud snapshots. All collections are owner-scoped, so an account can only ever read and write its own data.
+***
 
 ## \`v0.18.0-beta\` (2026-06-02) — QoL Updates, Shortcuts, and Onboarding
 - Added: Custom Fira Code font to the Notepad feature.

--- a/app/globals.css
+++ b/app/globals.css
@@ -754,3 +754,36 @@
   font-variant-ligatures: common-ligatures !important;
   font-feature-settings: "liga" on, "calt" on !important;
 }
+/* ── Sync rail ──────────────────────────────────────────────────────────────
+   The travelling marker on the device↔cloud rail. Direction carries meaning:
+   rightward is an upload, leftward is a download. */
+
+@keyframes _sync_travel_up {
+  0% { left: 0; opacity: 0; }
+  12% { opacity: 1; }
+  88% { opacity: 1; }
+  100% { left: 100%; opacity: 0; }
+}
+
+@keyframes _sync_travel_down {
+  0% { left: 100%; opacity: 0; }
+  12% { opacity: 1; }
+  88% { opacity: 1; }
+  100% { left: 0; opacity: 0; }
+}
+
+._sync_push {
+  animation: _sync_travel_up 1.2s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+}
+
+._sync_pull {
+  animation: _sync_travel_down 1.2s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ._sync_push,
+  ._sync_pull {
+    animation: none;
+    opacity: 0.7;
+  }
+}

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -23,6 +23,7 @@ import { AppSidebar } from "@/components/AppSidebar";
 import TopBar from "@/components/TopBar";
 import Onboarding from "@/components/onboarding/Onboarding";
 import GlobalShortcuts from "@/components/GlobalShortcuts";
+import SyncBridge from "@/components/auth/SyncBridge";
 
 /**
  * Boot Splash
@@ -77,12 +78,20 @@ export default function AppShell({
     return <BootSplash />;
   }
 
+  // Sync runs in both branches: someone can connect an account during
+  // onboarding to restore an existing profile onto a fresh device.
   if (needsOnboarding) {
-    return <Onboarding />;
+    return (
+      <>
+        <SyncBridge />
+        <Onboarding />
+      </>
+    );
   }
 
   return (
     <>
+      <SyncBridge />
       <AppSidebar />
       <GlobalShortcuts />
       <div className="flex-1 flex flex-col max-h-screen overflow-y-auto">

--- a/components/AppSidebar.tsx
+++ b/components/AppSidebar.tsx
@@ -32,6 +32,8 @@ import { FaReadme, FaUser } from "react-icons/fa6";
 import { THEMES, type ThemeDefinition } from "@/lib/ThemeManager";
 import { useTheme } from "next-themes";
 import { EditConfigForm } from "./sidebar/EditConfig";
+import AccountAvatar from "./auth/AccountAvatar";
+import { useAuth } from "@/hooks/useAuth";
 import { usePathname, useRouter } from "next/navigation";
 import { useConfig, type FeatureKey } from "@/hooks/useConfig";
 import { useEffect, useRef, useCallback, useState, type JSX } from "react";
@@ -278,6 +280,7 @@ const calculateAge = (dob: Date) => {
 
 function UserConfigButton({ loadingConfig }: { loadingConfig: boolean }): JSX.Element {
   const { name, dob } = useConfig();
+  const { user } = useAuth();
   const [open, setOpen] = useState(false);
 
   const hasName = name && name !== "NULL" && name.trim() !== "";
@@ -295,12 +298,10 @@ function UserConfigButton({ loadingConfig }: { loadingConfig: boolean }): JSX.El
           variant="ghost"
           className="w-full flex justify-start h-11 px-2.5 gap-2"
         >
-          {hasName ? (
-            /* eslint-disable-next-line @next/next/no-img-element */
-            <img
-              src={`https://api.dicebear.com/9.x/shapes/svg?seed=${name}`}
-              alt="avatar"
-              className="w-8 h-8 rounded-full shadow-md shrink-0"
+          {hasName || user ? (
+            <AccountAvatar
+              seed={name}
+              className="w-8 h-8 shadow-md shrink-0"
             />
           ) : (
             <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center border shadow-xs shrink-0">
@@ -308,9 +309,9 @@ function UserConfigButton({ loadingConfig }: { loadingConfig: boolean }): JSX.El
             </div>
           )}
           <div className="flex flex-col items-start text-left min-w-0">
-            {hasName ? (
+            {hasName || user ? (
               <span className="text-sm font-medium text-foreground truncate w-full">
-                {name}
+                {hasName ? name : user?.name || "Connected"}
               </span>
             ) : (
               <span className="text-sm font-medium text-muted-foreground">
@@ -333,7 +334,11 @@ function UserConfigButton({ loadingConfig }: { loadingConfig: boolean }): JSX.El
           </div>
         </Button>
       </PopoverTrigger>
-      <PopoverContent side="top" align="start" className="w-72 p-0">
+      <PopoverContent
+        side="top"
+        align="start"
+        className="w-80 p-0 max-h-[min(34rem,calc(100vh-5rem))] overflow-y-auto"
+      >
         <EditConfigForm onSave={() => setOpen(false)} />
       </PopoverContent>
     </Popover>

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -28,6 +28,7 @@ import BITFdata from "./BITFdata";
 import FloatingNotepad from "./FloatingNotepad";
 import QuickMessageDialog from "./QuickMessageDialog";
 import MiniTimer from "./MiniTimer";
+import SyncChip from "./auth/SyncChip";
 import { usePathname } from "next/navigation";
 import { FaTrash, FaHandHoldingDollar, FaCoins } from "react-icons/fa6";
 
@@ -41,6 +42,8 @@ const PAGE_TITLES: Record<string, string> = {
   "/rewards": "Rewards",
   "/excalidraw": "Excalidraw",
   "/changelog": "Changelog",
+  "/focus-table": "Focus Table",
+  "/account": "Account",
 };
 
 function usePageTitle(): string {
@@ -106,6 +109,7 @@ export default function TopBar(): JSX.Element {
           <MiniTimer />
           <div className="w-px h-5 bg-border mx-1" />
 
+          <SyncChip />
           <QuickMessageDialog />
           <FloatingNotepad />
           <BITFdata />

--- a/components/auth/AccountAvatar.tsx
+++ b/components/auth/AccountAvatar.tsx
@@ -1,0 +1,54 @@
+/**
+ * Account Avatar - Profile Picture With Fallback
+ *
+ * Shows the connected account's real profile picture, and falls back to the
+ * generated mark the app has always used for local-only profiles. Provider
+ * pictures are hosted elsewhere and can disappear or fail to load, so a broken
+ * image quietly becomes the generated one rather than an empty circle.
+ *
+ * @fileoverview Single source of truth for rendering a user's avatar.
+ * @author BIT Focus Development Team
+ * @since v0.19.0
+ */
+
+"use client";
+
+import { useEffect, useState, type JSX } from "react";
+import { useAuth } from "@/hooks/useAuth";
+import { resolveAvatarUrl } from "@/lib/pocketbase";
+import { cn } from "@/lib/utils";
+
+/**
+ * Account Avatar
+ *
+ * @param props.seed - Local profile name, used to generate the stand-in mark.
+ * @param props.className - Sizing and shape classes for the image.
+ */
+export default function AccountAvatar({
+  seed,
+  className,
+}: {
+  seed: string;
+  className?: string;
+}): JSX.Element {
+  const { user } = useAuth();
+  const preferred = resolveAvatarUrl(user, seed);
+  const generated = resolveAvatarUrl(null, user?.name || seed);
+
+  const [src, setSrc] = useState(preferred);
+
+  // Follow the account: signing in or out swaps the picture immediately.
+  useEffect(() => setSrc(preferred), [preferred]);
+
+  return (
+    /* eslint-disable-next-line @next/next/no-img-element */
+    <img
+      src={src}
+      alt=""
+      onError={() => {
+        if (src !== generated) setSrc(generated);
+      }}
+      className={cn("rounded-full object-cover", className)}
+    />
+  );
+}

--- a/components/auth/AccountPanel.tsx
+++ b/components/auth/AccountPanel.tsx
@@ -1,0 +1,162 @@
+/**
+ * Account Panel - Sync Status Inside the Profile Popover
+ *
+ * The compact face of account sync, shown at the top of the profile popover.
+ * Disconnected, it makes one offer. Connected, it answers the only two
+ * questions that matter in passing: which account is this, and is my data
+ * current — with a way to force the issue and a way out to the full page.
+ *
+ * @fileoverview Compact account and sync summary for the profile dropdown.
+ * @author BIT Focus Development Team
+ * @since v0.19.0
+ */
+
+"use client";
+
+import { useState, type JSX } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/hooks/useAuth";
+import { useSync } from "@/hooks/useSync";
+import { useConfig } from "@/hooks/useConfig";
+import { Button } from "@/components/ui/button";
+import AccountAvatar from "./AccountAvatar";
+import ConnectAccountDialog from "./ConnectAccountDialog";
+import SyncRail, { syncStatusLabel } from "./SyncRail";
+import { cn } from "@/lib/utils";
+import { toast } from "sonner";
+import {
+  FaArrowsRotate,
+  FaCloudArrowUp,
+  FaRightFromBracket,
+  FaSliders,
+} from "react-icons/fa6";
+
+/**
+ * Account Panel
+ *
+ * @param props.onNavigate - Called before routing away, so the host popover can
+ *   close itself.
+ */
+export default function AccountPanel({
+  onNavigate,
+}: {
+  onNavigate?: () => void;
+}): JSX.Element {
+  const router = useRouter();
+  const { user, signOut } = useAuth();
+  const { status, direction, dirty, syncedAt, syncNow } = useSync();
+  const { name } = useConfig();
+  const [connectOpen, setConnectOpen] = useState(false);
+
+  // ── Disconnected ─────────────────────────────────────────────────────────
+
+  if (!user) {
+    return (
+      <>
+        <div className="rounded-xl border border-primary/20 bg-primary/5 p-3.5 flex flex-col gap-3">
+          <div className="flex items-start gap-3">
+            <span className="grid place-items-center size-8 rounded-lg bg-primary/10 text-primary shrink-0">
+              <FaCloudArrowUp className="size-3.5" />
+            </span>
+            <div className="flex flex-col gap-0.5 min-w-0">
+              <p className="text-sm font-medium leading-none">
+                Sync across devices
+              </p>
+              <p className="text-[11px] text-muted-foreground leading-relaxed">
+                Your data lives only in this browser. Connect an account to pick
+                up where you left off anywhere.
+              </p>
+            </div>
+          </div>
+          <Button
+            size="sm"
+            className="w-full"
+            onClick={() => setConnectOpen(true)}
+          >
+            Connect an account
+          </Button>
+        </div>
+
+        <ConnectAccountDialog
+          open={connectOpen}
+          onOpenChange={setConnectOpen}
+          onConnected={() => toast.success("Account connected. Syncing now.")}
+        />
+      </>
+    );
+  }
+
+  // ── Connected ────────────────────────────────────────────────────────────
+
+  const busy = status === "busy";
+
+  return (
+    <div className="rounded-xl border bg-card p-3.5 flex flex-col gap-3">
+      <div className="flex items-center gap-2.5 min-w-0">
+        <AccountAvatar seed={name} className="size-9 shrink-0 border" />
+        <div className="flex flex-col min-w-0">
+          <span className="text-sm font-medium truncate">
+            {user.name || "Connected"}
+          </span>
+          <span className="text-[11px] text-muted-foreground truncate">
+            {user.email}
+          </span>
+        </div>
+      </div>
+
+      <SyncRail status={status} direction={direction} dirty={dirty} />
+
+      <div className="flex items-center justify-between gap-2">
+        <span
+          className={cn(
+            "text-[11px] uppercase tracking-widest",
+            status === "error" || status === "conflict"
+              ? "text-destructive"
+              : "text-muted-foreground",
+          )}
+        >
+          {syncStatusLabel(status, direction, dirty, syncedAt)}
+        </span>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-7 px-2 text-xs gap-1.5"
+          disabled={busy}
+          onClick={() => syncNow()}
+        >
+          <FaArrowsRotate
+            className={cn("size-3", busy && "motion-safe:animate-spin")}
+          />
+          Sync now
+        </Button>
+      </div>
+
+      <div className="flex gap-2 border-t pt-3">
+        <Button
+          size="sm"
+          variant="outline"
+          className="flex-1 h-8 text-xs gap-1.5"
+          onClick={() => {
+            onNavigate?.();
+            router.push("/account");
+          }}
+        >
+          <FaSliders className="size-3" />
+          Manage
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-8 text-xs gap-1.5"
+          onClick={() => {
+            signOut();
+            toast("Signed out. Your data stays on this device.");
+          }}
+        >
+          <FaRightFromBracket className="size-3" />
+          Sign out
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/auth/ConnectAccountDialog.tsx
+++ b/components/auth/ConnectAccountDialog.tsx
@@ -1,0 +1,91 @@
+/**
+ * Connect Account Dialog - Opt-In Sync Entry Point
+ *
+ * Shown wherever someone can turn on sync outside of onboarding. It states
+ * plainly what connecting does and what it does not do, then gets out of the
+ * way: three buttons, no forms, no password to invent.
+ *
+ * @fileoverview Dialog wrapper around the provider sign-in buttons.
+ * @author BIT Focus Development Team
+ * @since v0.19.0
+ */
+
+"use client";
+
+import { useState, type JSX, type ReactNode } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import ProviderButtons from "./ProviderButtons";
+import { FaArrowsRotate, FaLock } from "react-icons/fa6";
+
+/**
+ * Connect Account Dialog
+ *
+ * @param props.children - Optional trigger element.
+ * @param props.open - Controlled open state.
+ * @param props.onOpenChange - Controlled open state setter.
+ * @param props.onConnected - Called after a successful sign-in.
+ */
+export default function ConnectAccountDialog({
+  children,
+  open,
+  onOpenChange,
+  onConnected,
+}: {
+  children?: ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  onConnected?: () => void;
+}): JSX.Element {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isControlled = open !== undefined;
+  const isOpen = isControlled ? open : internalOpen;
+  const setOpen = isControlled ? (onOpenChange ?? (() => {})) : setInternalOpen;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setOpen}>
+      {children && <DialogTrigger asChild>{children}</DialogTrigger>}
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <span className="grid place-items-center size-10 rounded-xl bg-primary/10 text-primary mb-1">
+            <FaArrowsRotate className="size-4" />
+          </span>
+          <DialogTitle className="text-xl tracking-tight">
+            Take your focus with you
+          </DialogTitle>
+          <DialogDescription className="leading-relaxed">
+            Connect an account and BIT Focus keeps your sessions, projects,
+            tags, and rewards the same on every device you sign in on.
+          </DialogDescription>
+        </DialogHeader>
+
+        <ProviderButtons
+          className="pt-1"
+          onConnected={() => {
+            setOpen(false);
+            onConnected?.();
+          }}
+        />
+
+        <div className="flex items-start gap-3 rounded-xl border bg-card/50 p-3.5">
+          <span className="grid place-items-center size-8 rounded-lg bg-muted text-muted-foreground shrink-0">
+            <FaLock className="size-3.5" />
+          </span>
+          <p className="text-xs text-muted-foreground leading-relaxed">
+            <span className="font-medium text-foreground">
+              Your data stays yours.
+            </span>{" "}
+            Only your own account can read it. Sign out and everything keeps
+            working on this device exactly as before.
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/auth/ProviderButtons.tsx
+++ b/components/auth/ProviderButtons.tsx
@@ -1,0 +1,128 @@
+/**
+ * Provider Buttons - OAuth2 Sign-In Options
+ *
+ * The one place a person actually connects an account. Providers are read from
+ * the backend rather than hardcoded, so the buttons always reflect what is
+ * genuinely available — a provider that has not been configured never shows a
+ * button that would fail.
+ *
+ * Auth is not the moment for invention: each provider keeps its own mark and
+ * name so the row is scannable at a glance.
+ *
+ * @fileoverview Provider sign-in buttons with live availability.
+ * @author BIT Focus Development Team
+ * @since v0.19.0
+ */
+
+"use client";
+
+import { useEffect, type JSX } from "react";
+import { useAuth } from "@/hooks/useAuth";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import { FaGoogle, FaDiscord, FaGithub, FaKey } from "react-icons/fa6";
+import type { IconType } from "react-icons";
+
+/** Provider marks, keyed by the slug PocketBase reports. */
+const PROVIDER_ICONS: Record<string, IconType> = {
+  google: FaGoogle,
+  discord: FaDiscord,
+  github: FaGithub,
+};
+
+/**
+ * Provider Buttons
+ *
+ * @param props.onConnected - Called after a successful sign-in.
+ * @param props.className - Extra classes for the button stack.
+ */
+export default function ProviderButtons({
+  onConnected,
+  className,
+}: {
+  onConnected?: () => void;
+  className?: string;
+}): JSX.Element {
+  const {
+    providers,
+    loadProviders,
+    loadingProviders,
+    signIn,
+    signingIn,
+    pendingProvider,
+    error,
+  } = useAuth();
+
+  useEffect(() => {
+    loadProviders();
+  }, [loadProviders]);
+
+  const handle = async (provider: string) => {
+    const ok = await signIn(provider);
+    if (ok) onConnected?.();
+  };
+
+  if (loadingProviders && providers.length === 0) {
+    return (
+      <div className={cn("flex flex-col gap-2", className)}>
+        <Skeleton className="h-10 w-full rounded-lg" />
+        <Skeleton className="h-10 w-full rounded-lg" />
+        <Skeleton className="h-10 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (providers.length === 0) {
+    return (
+      <div
+        className={cn(
+          "rounded-xl border border-dashed bg-card/40 p-4 text-center",
+          className,
+        )}
+      >
+        <span className="grid place-items-center size-9 mx-auto rounded-lg bg-muted text-muted-foreground">
+          <FaKey className="size-3.5" />
+        </span>
+        <p className="mt-3 text-sm font-medium">No sign-in options yet</p>
+        <p className="mt-1 text-xs text-muted-foreground leading-relaxed">
+          Sign-in providers have not been switched on for this server. BIT Focus
+          keeps working on this device in the meantime.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("flex flex-col gap-2", className)}>
+      {providers.map((provider) => {
+        const Icon = PROVIDER_ICONS[provider.name] ?? FaKey;
+        const busy = signingIn && pendingProvider === provider.name;
+        return (
+          <Button
+            key={provider.name}
+            type="button"
+            variant="outline"
+            disabled={signingIn}
+            onClick={() => handle(provider.name)}
+            className="h-11 justify-start gap-3 px-4 font-medium"
+          >
+            <Icon
+              className={cn(
+                "size-4 shrink-0",
+                busy && "motion-safe:animate-pulse",
+              )}
+            />
+            <span>
+              {busy ? "Waiting for" : "Continue with"} {provider.displayName}
+            </span>
+          </Button>
+        );
+      })}
+
+      {error && (
+        <p className="text-xs text-destructive leading-relaxed pt-1">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/components/auth/SyncBridge.tsx
+++ b/components/auth/SyncBridge.tsx
@@ -1,0 +1,46 @@
+/**
+ * Sync Bridge - Auth to Engine Wiring
+ *
+ * Headless component that connects the account store to the sync engine and
+ * hosts the conflict dialog. Keeping the wiring here means neither store has to
+ * import the other, and mounting it once at the app root is the whole setup.
+ *
+ * @fileoverview Starts and stops sync as the account connects and disconnects.
+ * @author BIT Focus Development Team
+ * @since v0.19.0
+ */
+
+"use client";
+
+import { useEffect, type JSX } from "react";
+import { useAuth } from "@/hooks/useAuth";
+import { useSync } from "@/hooks/useSync";
+import SyncConflictDialog from "./SyncConflictDialog";
+
+/**
+ * Sync Bridge
+ *
+ * @returns The conflict dialog, which renders only when one is pending.
+ */
+export default function SyncBridge(): JSX.Element {
+  const { user, ready, init } = useAuth();
+  const { userId, attach, detach } = useSync();
+
+  useEffect(() => {
+    init();
+  }, [init]);
+
+  useEffect(() => {
+    if (!ready) return;
+
+    if (user && userId !== user.id) {
+      void attach(user.id);
+      return;
+    }
+    if (!user && userId) {
+      detach();
+    }
+  }, [ready, user, userId, attach, detach]);
+
+  return <SyncConflictDialog />;
+}

--- a/components/auth/SyncChip.tsx
+++ b/components/auth/SyncChip.tsx
@@ -1,0 +1,73 @@
+/**
+ * Sync Chip - Top Bar Sync Indicator
+ *
+ * A single glanceable mark in the top bar, present only when an account is
+ * connected. It answers "is my data safe" without being asked, and pressing it
+ * syncs immediately. When there is nothing to report it stays quiet — muted and
+ * unanimated — so it never competes with the timer beside it.
+ *
+ * @fileoverview Compact sync status and manual trigger for the top bar.
+ * @author BIT Focus Development Team
+ * @since v0.19.0
+ */
+
+"use client";
+
+import type { JSX } from "react";
+import { useAuth } from "@/hooks/useAuth";
+import { useSync } from "@/hooks/useSync";
+import { Button } from "@/components/ui/button";
+import { syncStatusLabel } from "./SyncRail";
+import { cn } from "@/lib/utils";
+import {
+  FaArrowsRotate,
+  FaCloud,
+  FaCloudArrowUp,
+  FaCodeBranch,
+  FaTriangleExclamation,
+} from "react-icons/fa6";
+
+/**
+ * Sync Chip
+ *
+ * @returns The indicator, or nothing when running without an account.
+ */
+export default function SyncChip(): JSX.Element | null {
+  const { user } = useAuth();
+  const { status, direction, dirty, syncedAt, syncNow } = useSync();
+
+  if (!user) return null;
+
+  const { Icon, tone, spin } = (() => {
+    switch (status) {
+      case "busy":
+        return { Icon: FaArrowsRotate, tone: "text-primary", spin: true };
+      case "error":
+        return { Icon: FaTriangleExclamation, tone: "text-destructive", spin: false };
+      case "conflict":
+        return { Icon: FaCodeBranch, tone: "text-destructive", spin: false };
+      default:
+        return dirty
+          ? { Icon: FaCloudArrowUp, tone: "text-muted-foreground", spin: false }
+          : { Icon: FaCloud, tone: "text-muted-foreground", spin: false };
+    }
+  })();
+
+  const label = syncStatusLabel(status, direction, dirty, syncedAt);
+
+  return (
+    <Button
+      size="icon"
+      variant="ghost"
+      className="size-8"
+      title={`Sync — ${label}`}
+      aria-label={`Sync status: ${label}. Press to sync now.`}
+      disabled={status === "busy"}
+      onClick={() => syncNow()}
+    >
+      <Icon
+        className={cn("size-3.5", tone, spin && "motion-safe:animate-spin")}
+      />
+    </Button>
+  );
+}

--- a/components/auth/SyncConflictDialog.tsx
+++ b/components/auth/SyncConflictDialog.tsx
@@ -1,0 +1,254 @@
+/**
+ * Sync Conflict Dialog - Choosing Between Two Versions
+ *
+ * Sync never merges silently. When this device and the cloud both changed since
+ * they last agreed, the engine stops and this dialog asks which version to
+ * keep — showing what each one actually holds, because "keep local or remote"
+ * is an impossible question without that.
+ *
+ * The two versions are laid out as facing ledgers in the same monospace,
+ * tabular register the rest of the app uses for counts, so differences line up
+ * row by row and are read rather than guessed at.
+ *
+ * @fileoverview Informed conflict resolution between local and cloud snapshots.
+ * @author BIT Focus Development Team
+ * @since v0.19.0
+ */
+
+"use client";
+
+import { useState, type JSX } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { useSync } from "@/hooks/useSync";
+import SyncManager, { type SnapshotSummary } from "@/lib/SyncManager";
+import { cn } from "@/lib/utils";
+import { FaLaptop, FaCloud, FaCodeBranch } from "react-icons/fa6";
+
+/** Rows compared side by side. Order runs from most to least telling. */
+const ROWS: { key: keyof SnapshotSummary; label: string }[] = [
+  { key: "focusSessions", label: "Sessions" },
+  { key: "projects", label: "Projects" },
+  { key: "notes", label: "Notes" },
+  { key: "timeblocks", label: "Timeblocks" },
+  { key: "drawings", label: "Drawings" },
+  { key: "chats", label: "Chats" },
+];
+
+/** Format a byte count at the coarsest useful precision. */
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Version Card
+ *
+ * One side of the comparison, selectable as the version to keep.
+ */
+function VersionCard({
+  title,
+  subtitle,
+  icon,
+  summary,
+  other,
+  selected,
+  onSelect,
+}: {
+  title: string;
+  subtitle: string;
+  icon: JSX.Element;
+  summary: SnapshotSummary;
+  other: SnapshotSummary;
+  selected: boolean;
+  onSelect: () => void;
+}): JSX.Element {
+  const newer =
+    !!summary.lastActivity &&
+    (!other.lastActivity || summary.lastActivity > other.lastActivity);
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={selected}
+      className={cn(
+        "flex flex-col gap-3 rounded-xl border bg-card p-4 text-left transition-colors",
+        selected
+          ? "border-primary ring-2 ring-primary/30"
+          : "border-border hover:border-primary/40",
+      )}
+    >
+      <div className="flex items-center gap-2.5">
+        <span
+          className={cn(
+            "grid place-items-center size-8 rounded-lg shrink-0",
+            selected
+              ? "bg-primary/10 text-primary"
+              : "bg-muted text-muted-foreground",
+          )}
+        >
+          {icon}
+        </span>
+        <div className="min-w-0">
+          <p className="text-sm font-medium truncate">{title}</p>
+          <p className="text-[11px] text-muted-foreground truncate">
+            {subtitle}
+          </p>
+        </div>
+      </div>
+
+      <div className="flex flex-col divide-y border-t">
+        {ROWS.map((row) => {
+          const value = summary[row.key] as number;
+          const compared = other[row.key] as number;
+          return (
+            <div
+              key={row.key}
+              className="flex items-center justify-between py-1.5"
+            >
+              <span className="text-[11px] uppercase tracking-widest text-muted-foreground">
+                {row.label}
+              </span>
+              <span
+                className={cn(
+                  "font-mono text-sm tabular-nums",
+                  value > compared && "text-primary font-semibold",
+                )}
+              >
+                {value}
+              </span>
+            </div>
+          );
+        })}
+        <div className="flex items-center justify-between py-1.5">
+          <span className="text-[11px] uppercase tracking-widest text-muted-foreground">
+            Size
+          </span>
+          <span className="font-mono text-sm tabular-nums text-muted-foreground">
+            {formatBytes(summary.bytes)}
+          </span>
+        </div>
+        {/* The deciding fact when both sides hold real data: which one was
+            actually being used most recently. */}
+        <div className="flex items-center justify-between py-1.5">
+          <span className="text-[11px] uppercase tracking-widest text-muted-foreground">
+            Last activity
+          </span>
+          <span
+            className={cn(
+              "font-mono text-sm tabular-nums",
+              newer ? "text-primary font-semibold" : "text-muted-foreground",
+            )}
+          >
+            {summary.lastActivity
+              ? summary.lastActivity.toLocaleDateString()
+              : "—"}
+          </span>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+/**
+ * Sync Conflict Dialog
+ *
+ * Rendered globally; opens only when the engine raises a conflict.
+ */
+export default function SyncConflictDialog(): JSX.Element | null {
+  const { conflict, resolveConflict, dismissConflict } = useSync();
+  const [keep, setKeep] = useState<"local" | "cloud">("local");
+  const [working, setWorking] = useState(false);
+
+  if (!conflict) return null;
+
+  const remoteUpdated = conflict.remoteUpdated
+    ? new Date(conflict.remoteUpdated).toLocaleString()
+    : "unknown";
+
+  const apply = async () => {
+    setWorking(true);
+    await resolveConflict(keep);
+    setWorking(false);
+  };
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open && !working) dismissConflict();
+      }}
+    >
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <span className="grid place-items-center size-10 rounded-xl bg-primary/10 text-primary mb-1">
+            <FaCodeBranch className="size-4" />
+          </span>
+          <DialogTitle className="text-xl tracking-tight">
+            {conflict.firstSync
+              ? "This device already has data"
+              : "Two versions of your data"}
+          </DialogTitle>
+          <DialogDescription className="leading-relaxed">
+            {conflict.firstSync
+              ? "Your account already holds a copy from another device, and this one has its own. Nothing is merged — pick the version to keep, and the other is replaced."
+              : "This device and the cloud both changed since they last agreed. Pick the version to keep — the other one is replaced."}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid sm:grid-cols-2 gap-3">
+          <VersionCard
+            title="This device"
+            subtitle={SyncManager.deviceLabel()}
+            icon={<FaLaptop className="size-3.5" />}
+            summary={conflict.local}
+            other={conflict.remote}
+            selected={keep === "local"}
+            onSelect={() => setKeep("local")}
+          />
+          <VersionCard
+            title="The cloud"
+            subtitle={`${conflict.remoteDeviceLabel} · ${remoteUpdated}`}
+            icon={<FaCloud className="size-3.5" />}
+            summary={conflict.remote}
+            other={conflict.local}
+            selected={keep === "cloud"}
+            onSelect={() => setKeep("cloud")}
+          />
+        </div>
+
+        <p className="text-xs text-muted-foreground leading-relaxed">
+          {keep === "local"
+            ? "Your cloud copy is replaced with what is on this device. Other devices will match it on their next sync."
+            : "This device is replaced with the cloud copy, and the app reloads. Anything changed here since the last sync is lost."}
+        </p>
+
+        <DialogFooter>
+          <Button
+            variant="ghost"
+            onClick={dismissConflict}
+            disabled={working}
+          >
+            Decide later
+          </Button>
+          <Button onClick={apply} disabled={working}>
+            {working
+              ? "Working…"
+              : keep === "local"
+                ? "Keep this device"
+                : "Use the cloud copy"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/auth/SyncRail.tsx
+++ b/components/auth/SyncRail.tsx
@@ -1,0 +1,155 @@
+/**
+ * Sync Rail - Device ↔ Cloud Link Indicator
+ *
+ * The signature element of the sync UI. BIT Focus already expresses progress as
+ * a dial, because a timer fills. Sync is not a filling thing — it is transit
+ * between two fixed points — so it gets a rail instead: this device at one end,
+ * the cloud at the other, and a marker whose direction of travel *is* the
+ * operation. Rightward means uploading, leftward means downloading.
+ *
+ * Every state is legible without reading a word: a lit rail is a live link, a
+ * dashed rail means changes are waiting, a rail broken in the middle means the
+ * two ends disagree.
+ *
+ * @fileoverview Directional link indicator for account sync.
+ * @author BIT Focus Development Team
+ * @since v0.19.0
+ */
+
+"use client";
+
+import type { JSX } from "react";
+import { cn } from "@/lib/utils";
+import type { SyncDirection, SyncStatus } from "@/hooks/useSync";
+import { FaLaptop, FaCloud } from "react-icons/fa6";
+
+/**
+ * Sync Rail
+ *
+ * @param props.status - Current engine status.
+ * @param props.direction - Which way data is moving right now, if at all.
+ * @param props.dirty - Whether local changes are waiting to be sent.
+ * @param props.className - Extra classes for the outer row.
+ */
+export default function SyncRail({
+  status,
+  direction,
+  dirty,
+  className,
+}: {
+  status: SyncStatus;
+  direction: SyncDirection;
+  dirty: boolean;
+  className?: string;
+}): JSX.Element {
+  const busy = status === "busy";
+  const broken = status === "conflict" || status === "error";
+  const live = status === "idle" && !dirty;
+
+  const capClass = (active: boolean) =>
+    cn(
+      "grid place-items-center size-8 rounded-lg border shrink-0 transition-colors",
+      active
+        ? "border-primary/40 bg-primary/10 text-primary"
+        : broken
+          ? "border-destructive/40 bg-destructive/10 text-destructive"
+          : "border-border bg-muted text-muted-foreground",
+    );
+
+  return (
+    <div className={cn("flex items-center gap-2.5", className)}>
+      <span className={capClass(live || direction === "push")} aria-hidden>
+        <FaLaptop className="size-3.5" />
+      </span>
+
+      <span className="relative flex-1 h-8 flex items-center" aria-hidden>
+        {/* The rail itself. A break in the middle reads as a broken link. */}
+        {broken ? (
+          <span className="flex-1 flex items-center gap-2">
+            <span className="flex-1 h-px bg-destructive/40" />
+            <span className="size-1 rounded-full bg-destructive/60" />
+            <span className="flex-1 h-px bg-destructive/40" />
+          </span>
+        ) : (
+          <span
+            className={cn(
+              "flex-1 h-px transition-colors",
+              live ? "bg-primary/40" : "bg-border",
+            )}
+            style={
+              dirty && !busy
+                ? {
+                    backgroundImage:
+                      "repeating-linear-gradient(to right, var(--border) 0 4px, transparent 4px 8px)",
+                    backgroundColor: "transparent",
+                  }
+                : undefined
+            }
+          />
+        )}
+
+        {/* Travelling marker, shown only while data is actually moving. */}
+        {busy && direction && (
+          <span
+            className={cn(
+              "absolute top-1/2 -translate-y-1/2 h-[3px] w-6 -ml-3 rounded-full bg-primary",
+              direction === "push" ? "_sync_push" : "_sync_pull",
+            )}
+          />
+        )}
+      </span>
+
+      <span className={capClass(live || direction === "pull")} aria-hidden>
+        <FaCloud className="size-3.5" />
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Format a sync timestamp the way a person would say it.
+ *
+ * @param iso - ISO timestamp of the last successful sync, or null.
+ * @returns A short relative phrase, e.g. `3 min ago`.
+ */
+export function formatSyncTime(iso: string | null): string {
+  if (!iso) return "never";
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return "never";
+
+  const seconds = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (seconds < 10) return "just now";
+  if (seconds < 60) return `${seconds}s ago`;
+
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes} min ago`;
+
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  const days = Math.round(hours / 24);
+  if (days < 30) return `${days}d ago`;
+
+  return new Date(then).toLocaleDateString();
+}
+
+/** One-line description of the engine state, for status text next to the rail. */
+export function syncStatusLabel(
+  status: SyncStatus,
+  direction: SyncDirection,
+  dirty: boolean,
+  syncedAt: string | null,
+): string {
+  switch (status) {
+    case "off":
+      return "Not connected";
+    case "busy":
+      return direction === "pull" ? "Downloading…" : "Uploading…";
+    case "error":
+      return "Sync failed";
+    case "conflict":
+      return "Needs a decision";
+    default:
+      return dirty ? "Changes waiting" : `Synced ${formatSyncTime(syncedAt)}`;
+  }
+}

--- a/components/onboarding/Onboarding.tsx
+++ b/components/onboarding/Onboarding.tsx
@@ -36,6 +36,9 @@ import {
 import { useTheme } from "next-themes";
 import { useConfig } from "@/hooks/useConfig";
 import { useTag } from "@/hooks/useTag";
+import { useAuth } from "@/hooks/useAuth";
+import ProviderButtons from "@/components/auth/ProviderButtons";
+import AccountAvatar from "@/components/auth/AccountAvatar";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -58,6 +61,8 @@ import {
   FaPlus,
   FaBell,
   FaLock,
+  FaCloudArrowDown,
+  FaLaptop,
 } from "react-icons/fa6";
 import { THEMES } from "@/lib/ThemeManager";
 
@@ -66,6 +71,7 @@ import { THEMES } from "@/lib/ThemeManager";
 /** Ordered step metadata. `eyebrow` labels the dial; `title` heads the panel. */
 const STEPS = [
   { eyebrow: "Welcome", title: "Focus, for a bit." },
+  { eyebrow: "Account", title: "Been here before?" },
   { eyebrow: "Appearance", title: "Pick your palette." },
   { eyebrow: "Identity", title: "Who's focusing?" },
   { eyebrow: "Tags", title: "What will you track?" },
@@ -272,8 +278,8 @@ export default function Onboarding(): JSX.Element {
 
   /** Whether the current step may advance to the next. */
   const canAdvance = (() => {
-    if (step === 2) return hasName && !dobInvalid; // identity
-    if (step === 4) return !webhookInvalid; // notifications
+    if (step === 3) return hasName && !dobInvalid; // identity
+    if (step === 5) return !webhookInvalid; // notifications
     return true;
   })();
 
@@ -379,8 +385,9 @@ export default function Onboarding(): JSX.Element {
             <div className="mt-8" key={step}>
               <div className="_animate_in">
                 {step === 0 && <WelcomeStep />}
-                {step === 1 && <ThemeStep />}
-                {step === 2 && (
+                {step === 1 && <AccountStep onNameFromAccount={setName} />}
+                {step === 2 && <ThemeStep />}
+                {step === 3 && (
                   <IdentityStep
                     name={name}
                     setName={setName}
@@ -395,7 +402,7 @@ export default function Onboarding(): JSX.Element {
                     dobInvalid={dobInvalid}
                   />
                 )}
-                {step === 3 && (
+                {step === 4 && (
                   <TagsStep
                     picked={picked}
                     isPicked={isPicked}
@@ -410,7 +417,7 @@ export default function Onboarding(): JSX.Element {
                     }
                   />
                 )}
-                {step === 4 && (
+                {step === 5 && (
                   <NotificationsStep
                     webhook={webhook}
                     setWebhook={setWebhook}
@@ -420,7 +427,7 @@ export default function Onboarding(): JSX.Element {
                     setSendUpdates={setSendUpdates}
                   />
                 )}
-                {step === 5 && (
+                {step === 6 && (
                   <ReadyStep
                     name={trimmedName}
                     age={age}
@@ -471,8 +478,9 @@ function WelcomeStep(): JSX.Element {
     <div className="flex flex-col gap-6">
       <p className="text-muted-foreground leading-relaxed">
         BIT Focus keeps a quiet record of your focused time and the work it goes
-        into. No accounts, no cloud — everything lives in this browser. Here&apos;s
-        what you get.
+        into. Everything lives in this browser by default — connect an account
+        later only if you want it on more than one device. Here&apos;s what you
+        get.
       </p>
       <div className="grid sm:grid-cols-2 gap-3">
         {FEATURES.map((f) => (
@@ -489,6 +497,97 @@ function WelcomeStep(): JSX.Element {
             </p>
           </div>
         ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Account Step
+ *
+ * Placed second on purpose. Someone reinstalling or setting up a second device
+ * should not have to fill in a profile that already exists in the cloud — if
+ * they connect here and this device is empty, the sync engine restores
+ * everything and the rest of onboarding becomes unnecessary.
+ *
+ * @param props.onNameFromAccount - Seeds the identity step with the provider
+ *   name, so the next screen is already filled in.
+ */
+function AccountStep({
+  onNameFromAccount,
+}: {
+  onNameFromAccount: (name: string) => void;
+}): JSX.Element {
+  const { user } = useAuth();
+
+  if (user) {
+    return (
+      <div className="flex flex-col gap-6">
+        <p className="text-muted-foreground leading-relaxed">
+          Connected. Anything you set up from here on will be waiting on your
+          other devices.
+        </p>
+
+        <div className="flex items-center gap-3 rounded-xl border border-primary/30 bg-primary/5 p-4">
+          <AccountAvatar seed={user.name} className="size-11 border shrink-0" />
+          <div className="flex flex-col min-w-0">
+            <span className="font-medium truncate">
+              {user.name || "Your account"}
+            </span>
+            <span className="text-xs text-muted-foreground truncate">
+              {user.email}
+            </span>
+          </div>
+          <FaCheck className="size-4 text-primary ml-auto shrink-0" />
+        </div>
+
+        <p className="text-xs text-muted-foreground leading-relaxed">
+          Had data on another device? It has already been restored if there was
+          any to restore.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <p className="text-muted-foreground leading-relaxed">
+        If you&apos;ve used BIT Focus before, sign in and your sessions,
+        projects, and tags come back exactly as you left them. Starting fresh?
+        Skip this — you can connect any time.
+      </p>
+
+      <ProviderButtons
+        onConnected={() => {
+          // The provider name is a sensible default for the identity step.
+          const connected = useAuth.getState().user;
+          if (connected?.name) onNameFromAccount(connected.name);
+          toast(`Signed in as ${connected?.email ?? "you"}.`, {
+            icon: <FaCheck />,
+          });
+        }}
+      />
+
+      <div className="grid sm:grid-cols-2 gap-3">
+        <div className="rounded-xl border bg-card p-4 flex flex-col gap-2">
+          <span className="grid place-items-center size-9 rounded-lg bg-primary/10 text-primary">
+            <FaCloudArrowDown className="size-4" />
+          </span>
+          <p className="font-medium text-sm">Pick up anywhere</p>
+          <p className="text-xs text-muted-foreground leading-relaxed">
+            Start a session on your laptop, check the numbers on your phone.
+          </p>
+        </div>
+        <div className="rounded-xl border bg-card p-4 flex flex-col gap-2">
+          <span className="grid place-items-center size-9 rounded-lg bg-muted text-muted-foreground">
+            <FaLaptop className="size-4" />
+          </span>
+          <p className="font-medium text-sm">Stays optional</p>
+          <p className="text-xs text-muted-foreground leading-relaxed">
+            Every feature works signed out. Nothing leaves this browser until
+            you say so.
+          </p>
+        </div>
       </div>
     </div>
   );
@@ -586,8 +685,8 @@ function IdentityStep({
           <span className="font-medium text-foreground">
             This stays on your device.
           </span>{" "}
-          BIT Focus has no accounts and no servers — your name and details are
-          saved only in this browser and never sent anywhere.
+          Your name and details are saved in this browser. They leave it only if
+          you connect an account, and then only to your own account.
         </p>
       </div>
 
@@ -858,11 +957,14 @@ function ReadyStep({
   tagCount: number;
   notify: boolean;
 }): JSX.Element {
+  const { user } = useAuth();
+
   const rows = [
     { label: "Name", value: name || "—" },
     { label: "Age", value: age != null ? `${age}` : "Not set" },
     { label: "Starter tags", value: `${tagCount}` },
     { label: "Status updates", value: notify ? "On" : "Off" },
+    { label: "Sync", value: user ? "On" : "This device only" },
   ];
 
   return (

--- a/components/sidebar/EditConfig.tsx
+++ b/components/sidebar/EditConfig.tsx
@@ -11,6 +11,7 @@ import { Button } from "../ui/button";
 import { Label } from "../ui/label";
 import { Input } from "../ui/input";
 import CurrencySelect from "@/components/CurrencySelect";
+import AccountPanel from "@/components/auth/AccountPanel";
 import dayjs from "dayjs";
 import { cn } from "@/lib/utils";
 
@@ -110,6 +111,10 @@ export function EditConfigForm({ onSave }: { onSave?: () => void }) {
 
   return (
     <div className="grid gap-4 p-4">
+      {/* Account and sync sit above the local profile fields: connecting is the
+          one thing here that changes where the data lives. */}
+      <AccountPanel onNavigate={onSave} />
+
       <div className="space-y-1">
         <h4 className="font-medium leading-none text-sm">Edit Details</h4>
       </div>

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -1,0 +1,241 @@
+/**
+ * Authentication Hook - Optional Account Connection
+ *
+ * Wraps the PocketBase auth store in a Zustand store so any component can read
+ * the current account without prop drilling. Everything here is optional by
+ * design: BIT Focus runs entirely on-device until someone connects an account,
+ * and signing out returns it to exactly that state.
+ *
+ * Sign-in is OAuth2 popup based. The provider list is fetched from the backend
+ * rather than hardcoded, so enabling Discord or GitHub in the PocketBase admin
+ * makes the button appear here with no code change.
+ *
+ * @fileoverview Account connection state and OAuth2 sign-in actions.
+ * @author BIT Focus Development Team
+ * @since v0.19.0
+ */
+
+import { create } from "zustand";
+import {
+  pb,
+  USERS_COLLECTION,
+  SUPPORTED_PROVIDERS,
+  type AuthUser,
+  type ProviderName,
+} from "@/lib/pocketbase";
+
+/** A provider the backend has configured and is ready to authenticate with. */
+export interface AvailableProvider {
+  /** Provider slug, e.g. `google`. */
+  name: string;
+  /** Provider-supplied display name, e.g. `Google`. */
+  displayName: string;
+}
+
+interface AuthState {
+  /** Currently connected account, or null when running local-only. */
+  user: AuthUser | null;
+  /** True once the initial auth check has settled. */
+  ready: boolean;
+  /** True while a sign-in round trip is in flight. */
+  signingIn: boolean;
+  /** Provider slug currently being authenticated, for per-button spinners. */
+  pendingProvider: string | null;
+  /** Providers enabled on the backend, ordered for display. */
+  providers: AvailableProvider[];
+  /** True while the provider list is being fetched. */
+  loadingProviders: boolean;
+  /** Last sign-in error, surfaced next to the provider buttons. */
+  error: string | null;
+
+  /** Restore and validate any persisted session. Safe to call repeatedly. */
+  init: () => Promise<void>;
+  /** Fetch the provider list from the backend. */
+  loadProviders: () => Promise<void>;
+  /** Open the provider popup and connect an account. Resolves to success. */
+  signIn: (provider: ProviderName | string) => Promise<boolean>;
+  /** Disconnect the account on this device. Local data is left untouched. */
+  signOut: () => void;
+  /** Permanently delete the account and its cloud snapshot. */
+  deleteAccount: () => Promise<void>;
+  /** Clear the current error message. */
+  clearError: () => void;
+}
+
+/**
+ * Order providers the way the app presents them, keeping any extra provider
+ * the backend enables later at the end of the list rather than dropping it.
+ */
+function orderProviders(providers: AvailableProvider[]): AvailableProvider[] {
+  const rank = (name: string) => {
+    const i = SUPPORTED_PROVIDERS.indexOf(name as ProviderName);
+    return i === -1 ? SUPPORTED_PROVIDERS.length : i;
+  };
+  return [...providers].sort((a, b) => rank(a.name) - rank(b.name));
+}
+
+/**
+ * Guards the startup auth check.
+ *
+ * `init` is called from a component effect, so React's development double-mount
+ * would otherwise fire two identical `authRefresh` requests. The second one
+ * aborts the first, and an aborted refresh used to read as a dead session —
+ * which signed the user out on every reload.
+ */
+let initPromise: Promise<void> | null = null;
+
+/**
+ * Whether a failed refresh means the session is genuinely gone.
+ *
+ * Only the server rejecting the token counts. Aborts, offline errors, and
+ * server faults are transient: the cached session stays, because throwing away
+ * a valid token over a blip is far worse than trusting it a little longer.
+ *
+ * @param error - Whatever `authRefresh` threw.
+ */
+function isSessionRejected(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const { status, isAbort } = error as { status?: number; isAbort?: boolean };
+  if (isAbort) return false;
+  return status === 401 || status === 403 || status === 404;
+}
+
+/** Narrow an unknown throwable into a message worth showing a person. */
+function messageFor(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message) {
+    // PocketBase surfaces a popup-blocked failure with this exact wording.
+    if (/popup|window/i.test(error.message)) {
+      return "The sign-in window was blocked. Allow popups for this site and try again.";
+    }
+    return error.message;
+  }
+  return fallback;
+}
+
+export const useAuth = create<AuthState>((set, get) => ({
+  user: (pb.authStore.record as AuthUser | null) ?? null,
+  ready: false,
+  signingIn: false,
+  pendingProvider: null,
+  providers: [],
+  loadingProviders: false,
+  error: null,
+
+  init: async () => {
+    if (initPromise) return initPromise;
+
+    initPromise = (async () => {
+      // Mirror every future auth store change into React state.
+      pb.authStore.onChange(() => {
+        set({ user: (pb.authStore.record as AuthUser | null) ?? null });
+      }, false);
+
+      if (!pb.authStore.isValid) {
+        set({ user: null, ready: true });
+        return;
+      }
+
+      // Trust the stored session immediately. The refresh below only ever
+      // confirms or revokes it, and the app should not flicker through a
+      // signed-out state while that round trip is in flight.
+      const cached = (pb.authStore.record as AuthUser | null) ?? null;
+      set({ user: cached, ready: true });
+
+      try {
+        // Catch a revoked or deleted account. `requestKey: null` opts this
+        // request out of deduplication so a concurrent caller cannot abort it.
+        const result = await pb
+          .collection(USERS_COLLECTION)
+          .authRefresh({ requestKey: null });
+        set({ user: result.record as AuthUser });
+      } catch (error) {
+        if (isSessionRejected(error)) {
+          pb.authStore.clear();
+          set({ user: null });
+          return;
+        }
+        // Offline, aborted, or the server is unwell — keep the session and
+        // carry on with the cached account.
+        set({ user: cached });
+      }
+    })();
+
+    return initPromise;
+  },
+
+  loadProviders: async () => {
+    set({ loadingProviders: true });
+    try {
+      const methods = await pb.collection(USERS_COLLECTION).listAuthMethods();
+      const list = (methods.oauth2?.providers ?? []).map((p) => ({
+        name: p.name,
+        displayName: p.displayName || p.name,
+      }));
+      set({ providers: orderProviders(list), loadingProviders: false });
+    } catch {
+      set({ providers: [], loadingProviders: false });
+    }
+  },
+
+  signIn: async (provider) => {
+    set({ signingIn: true, pendingProvider: provider, error: null });
+    try {
+      const result = await pb
+        .collection(USERS_COLLECTION)
+        .authWithOAuth2({ provider });
+
+      const record = result.record as AuthUser;
+
+      // Record which provider was used and backfill the picture on first
+      // connect. The provider is informational — it drives the badge shown in
+      // the account UI so a returning user knows which button to press.
+      const patch: Record<string, string> = {};
+      if (record.provider !== provider) patch.provider = provider;
+      const avatar = result.meta?.avatarURL as string | undefined;
+      if (avatar && !record.avatarUrl) patch.avatarUrl = avatar;
+      const name = result.meta?.name as string | undefined;
+      if (name && !record.name) patch.name = name;
+
+      if (Object.keys(patch).length > 0) {
+        try {
+          const updated = await pb
+            .collection(USERS_COLLECTION)
+            .update(record.id, patch);
+          set({ user: updated as AuthUser });
+        } catch {
+          // Non-fatal: the session is valid either way.
+          set({ user: record });
+        }
+      } else {
+        set({ user: record });
+      }
+
+      set({ signingIn: false, pendingProvider: null });
+      return true;
+    } catch (error) {
+      set({
+        signingIn: false,
+        pendingProvider: null,
+        error: messageFor(error, "Could not complete sign-in. Try again."),
+      });
+      return false;
+    }
+  },
+
+  signOut: () => {
+    pb.authStore.clear();
+    set({ user: null, error: null });
+  },
+
+  deleteAccount: async () => {
+    const user = get().user;
+    if (!user) return;
+    // The snapshot relation cascades, so deleting the account removes the
+    // cloud copy of the data with it.
+    await pb.collection(USERS_COLLECTION).delete(user.id);
+    pb.authStore.clear();
+    set({ user: null });
+  },
+
+  clearError: () => set({ error: null }),
+}));

--- a/hooks/useSync.ts
+++ b/hooks/useSync.ts
@@ -1,0 +1,561 @@
+/**
+ * Sync Hook - Background Sync Engine
+ *
+ * Decides *when* data moves between this device and the cloud. The mechanics
+ * of moving it live in `lib/SyncManager.ts`; this store owns the policy, the
+ * status a person sees, and the conflict question when the two sides disagree.
+ *
+ * How it stays current:
+ * - Dexie table hooks flag the snapshot dirty the moment any record changes.
+ * - A localStorage interceptor covers the state that lives outside IndexedDB
+ *   (saved tags, timer settings, ambience) without touching each store.
+ * - A debounce pushes shortly after activity stops; a heartbeat and the
+ *   page-hide event catch anything the debounce missed.
+ * - A realtime subscription pulls the moment another device writes.
+ *
+ * Conflicts are never merged silently. When both sides moved since this device
+ * last synced, the engine stops and asks, showing what each version holds.
+ *
+ * @fileoverview Sync scheduling, status, and conflict resolution.
+ * @author BIT Focus Development Team
+ * @since v0.19.0
+ */
+
+import { create } from "zustand";
+import db from "@/lib/db";
+import SyncManager, {
+  type SnapshotSummary,
+  type SyncPayload,
+} from "@/lib/SyncManager";
+import { pb, SYNC_COLLECTION } from "@/lib/pocketbase";
+import { isProtectedLocalKey } from "@/lib/SaveManager";
+import { VERSION } from "@/app/changelog/CHANGELOG";
+
+/** Milliseconds of quiet before a change is pushed. */
+const PUSH_DEBOUNCE_MS = 4000;
+
+/** Milliseconds between safety-net flushes. */
+const HEARTBEAT_MS = 60_000;
+
+/** Coarse status shown in the UI. */
+export type SyncStatus = "off" | "idle" | "busy" | "error" | "conflict";
+
+/** Which way data is currently moving, for directional affordances. */
+export type SyncDirection = "push" | "pull" | null;
+
+/** The two candidate versions when a conflict needs a decision. */
+export interface SyncConflict {
+  local: SnapshotSummary;
+  remote: SnapshotSummary;
+  remoteRevision: number;
+  remoteUpdated: string;
+  remoteDeviceLabel: string;
+  remotePayload: SyncPayload;
+  remoteRecordId: string;
+  /**
+   * True when this device is meeting the account for the first time and
+   * already had data of its own. There is no shared baseline in that case, so
+   * neither side can be called "ahead" — only the user can decide.
+   */
+  firstSync: boolean;
+}
+
+interface SyncState {
+  /** Account whose snapshot this device is syncing, or null when signed out. */
+  userId: string | null;
+  status: SyncStatus;
+  direction: SyncDirection;
+  /** True when local data has changed since the last successful sync. */
+  dirty: boolean;
+  /** Revision this device last agreed on with the cloud. */
+  revision: number;
+  /** ISO timestamp of the last successful sync. */
+  syncedAt: string | null;
+  /** Label of the device that last wrote to the cloud. */
+  lastWriter: string | null;
+  /** Whether background sync runs on this device. */
+  auto: boolean;
+  /** Message from the last failure, cleared on the next success. */
+  error: string | null;
+  /** Pending conflict awaiting a decision, if any. */
+  conflict: SyncConflict | null;
+
+  /** Begin syncing for an account. Idempotent. */
+  attach: (userId: string) => Promise<void>;
+  /** Stop syncing and forget this device's position. */
+  detach: () => void;
+  /** Flag local data as changed. */
+  markDirty: () => void;
+  /** Reconcile now, choosing push or pull as appropriate. */
+  syncNow: () => Promise<void>;
+  /** Upload this device's data, overwriting the cloud copy. */
+  forcePush: () => Promise<void>;
+  /** Download the cloud copy, overwriting this device's data. */
+  forcePull: () => Promise<void>;
+  /** Settle a pending conflict by keeping one side. */
+  resolveConflict: (keep: "local" | "cloud") => Promise<void>;
+  /** Dismiss a conflict without changing anything. Sync stays paused. */
+  dismissConflict: () => void;
+  /** Turn background sync on or off for this device. */
+  setAuto: (auto: boolean) => void;
+  /** Delete the cloud snapshot, keeping the account and local data. */
+  deleteCloudCopy: () => Promise<void>;
+}
+
+// ── Engine internals ─────────────────────────────────────────────────────────
+// Kept outside the store: these are side-effect handles, not rendered state.
+
+let hooksInstalled = false;
+let listenersInstalled = false;
+let realtimeUnsub: (() => void) | null = null;
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+let heartbeat: ReturnType<typeof setInterval> | null = null;
+
+/** Suppresses dirty-flagging while the engine itself is writing local data. */
+let applying = false;
+
+/** Serializes sync operations so two pushes never race. */
+let chain: Promise<unknown> = Promise.resolve();
+
+/** Run an operation after any in-flight sync work finishes. */
+function serialize<T>(op: () => Promise<T>): Promise<T> {
+  const next = chain.then(op, op);
+  chain = next.catch(() => undefined);
+  return next;
+}
+
+/** Turn an unknown throwable into a message worth showing. */
+function messageFor(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message;
+  return "Sync failed. It will retry automatically.";
+}
+
+/**
+ * Reload after the local database has been replaced.
+ *
+ * Every store in the app holds its slice of IndexedDB in memory. Rather than
+ * hand-refreshing each one and hoping none is missed, the engine restarts the
+ * app — the timer and its settings live in localStorage and survive intact.
+ */
+function reloadIntoRestoredData(): void {
+  if (typeof window === "undefined") return;
+  window.setTimeout(() => window.location.reload(), 700);
+}
+
+export const useSync = create<SyncState>((set, get) => {
+  /** Push local data up, stamping the next revision. */
+  async function performPush(force: boolean): Promise<void> {
+    const { userId, auto } = get();
+    if (!userId) return;
+    if (!force && !auto) return;
+
+    set({ status: "busy", direction: "push", error: null });
+    try {
+      const local = SyncManager.readState();
+      const head = await SyncManager.fetchHead(userId);
+
+      // Someone else moved the cloud forward. Unless the user explicitly chose
+      // this device, that is a question, not something to overwrite.
+      if (head && head.revision > local.revision && !force) {
+        await raiseConflictOrAdopt(userId, head.id);
+        return;
+      }
+
+      const payload = await SyncManager.snapshot();
+      const revision = Math.max(local.revision, head?.revision ?? 0) + 1;
+      const record = await SyncManager.write(
+        userId,
+        payload,
+        revision,
+        head?.id ?? local.recordId,
+        VERSION,
+      );
+
+      const syncedAt = new Date().toISOString();
+      SyncManager.writeState({ revision, syncedAt, recordId: record.id });
+      set({
+        status: "idle",
+        direction: null,
+        dirty: false,
+        revision,
+        syncedAt,
+        lastWriter: SyncManager.deviceLabel(),
+        error: null,
+      });
+    } catch (error) {
+      set({ status: "error", direction: null, error: messageFor(error) });
+    }
+  }
+
+  /** Pull cloud data down, replacing local data. */
+  async function performPull(payload?: SyncPayload, revision?: number, recordId?: string): Promise<void> {
+    const { userId } = get();
+    if (!userId) return;
+
+    set({ status: "busy", direction: "pull", error: null });
+    try {
+      let data = payload;
+      let rev = revision;
+      let id = recordId;
+
+      if (!data) {
+        const record = await SyncManager.fetchRecord(userId);
+        if (!record) {
+          // Nothing to pull; this device becomes the source of truth.
+          await performPush(true);
+          return;
+        }
+        data = record.payload;
+        rev = record.revision ?? 0;
+        id = record.id;
+      }
+
+      applying = true;
+      await SyncManager.apply(data);
+      applying = false;
+
+      const syncedAt = new Date().toISOString();
+      SyncManager.writeState({
+        revision: rev ?? 0,
+        syncedAt,
+        recordId: id ?? null,
+      });
+      set({
+        status: "idle",
+        direction: null,
+        dirty: false,
+        revision: rev ?? 0,
+        syncedAt,
+        conflict: null,
+        error: null,
+      });
+      reloadIntoRestoredData();
+    } catch (error) {
+      applying = false;
+      set({ status: "error", direction: null, error: messageFor(error) });
+    }
+  }
+
+  /**
+   * The cloud moved ahead. Adopt it when this device has nothing at stake,
+   * otherwise stop and ask.
+   *
+   * @param userId - Account being synced.
+   * @param knownRecordId - Remote record id, when already known.
+   * @param firstSync - True when this device has never synced with this
+   *   account. Signing in is not a change, so the dirty flag says nothing
+   *   here — a device with its own data must always be asked, or its history
+   *   would be destroyed by the act of signing in.
+   */
+  async function raiseConflictOrAdopt(
+    userId: string,
+    knownRecordId?: string,
+    firstSync = false,
+  ): Promise<void> {
+    const record = await SyncManager.fetchRecord(userId);
+    if (!record) {
+      await performPush(true);
+      return;
+    }
+
+    const localPayload = await SyncManager.snapshot();
+
+    // Nothing here worth keeping: adopt the cloud without interrupting.
+    if (SyncManager.isEmpty(localPayload)) {
+      await performPull(record.payload, record.revision ?? 0, record.id);
+      return;
+    }
+
+    // Past the first sync, a clean device is simply behind and can fast-forward.
+    if (!firstSync && !get().dirty) {
+      await performPull(record.payload, record.revision ?? 0, record.id);
+      return;
+    }
+
+    set({
+      status: "conflict",
+      direction: null,
+      conflict: {
+        local: SyncManager.summarize(localPayload),
+        remote: SyncManager.summarize(record.payload),
+        remoteRevision: record.revision ?? 0,
+        remoteUpdated: record.updated,
+        remoteDeviceLabel: record.deviceLabel || "another device",
+        remotePayload: record.payload,
+        remoteRecordId: knownRecordId ?? record.id,
+        firstSync,
+      },
+    });
+  }
+
+  /** Debounced push, called after local changes settle. */
+  function schedulePush(): void {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      const { userId, auto, status } = get();
+      if (!userId || !auto || status === "conflict") return;
+      void serialize(() => performPush(false));
+    }, PUSH_DEBOUNCE_MS);
+  }
+
+  /**
+   * Watch every local write.
+   *
+   * Dexie hooks cover the database; the localStorage interceptor covers the
+   * rest. Both run once per page load and stay installed — they only ever set
+   * a flag, so they are cheap enough to leave in place after signing out.
+   */
+  function installChangeWatchers(): void {
+    if (hooksInstalled || typeof window === "undefined") return;
+    hooksInstalled = true;
+
+    const touch = () => {
+      if (applying) return;
+      const { userId } = get();
+      if (!userId) return;
+      if (!get().dirty) set({ dirty: true });
+      schedulePush();
+    };
+
+    for (const table of db.tables) {
+      table.hook("creating", () => {
+        touch();
+      });
+      table.hook("updating", () => {
+        touch();
+      });
+      table.hook("deleting", () => {
+        touch();
+      });
+    }
+
+    // Saved tags, timer settings, and ambience live in localStorage rather than
+    // Dexie. Intercepting the setter keeps them in sync without every store
+    // having to know sync exists.
+    const nativeSetItem = window.localStorage.setItem.bind(window.localStorage);
+    window.localStorage.setItem = (key: string, value: string) => {
+      nativeSetItem(key, value);
+      if (!isProtectedLocalKey(key)) touch();
+    };
+  }
+
+  /** Flush on page hide and re-check when the tab comes back. */
+  function installLifecycleListeners(): void {
+    if (listenersInstalled || typeof window === "undefined") return;
+    listenersInstalled = true;
+
+    window.addEventListener("pagehide", () => {
+      const { userId, auto, dirty, status } = get();
+      if (!userId || !auto || !dirty || status === "conflict") return;
+      // Best-effort: the browser may cut this short, and the heartbeat on the
+      // next visit will finish the job.
+      void serialize(() => performPush(false));
+    });
+
+    document.addEventListener("visibilitychange", () => {
+      if (document.visibilityState !== "visible") return;
+      const { userId, auto, status } = get();
+      if (!userId || !auto || status === "conflict") return;
+      void serialize(() => get().syncNow());
+    });
+  }
+
+  /** Subscribe to cloud writes from this account's other devices. */
+  async function subscribeRealtime(userId: string): Promise<void> {
+    if (realtimeUnsub) return;
+    try {
+      const unsub = await pb
+        .collection(SYNC_COLLECTION)
+        .subscribe("*", (event) => {
+          const record = event.record as unknown as {
+            device?: string;
+            revision?: number;
+            deviceLabel?: string;
+          };
+          // Ignore the echo of our own write.
+          if (record.device === SyncManager.deviceId()) return;
+          if ((record.revision ?? 0) <= get().revision) return;
+          set({ lastWriter: record.deviceLabel ?? null });
+          const { auto, status } = get();
+          if (!auto || status === "conflict") return;
+          void serialize(() => raiseConflictOrAdopt(userId));
+        });
+      realtimeUnsub = unsub;
+    } catch {
+      // Realtime is an accelerator, not a requirement — the heartbeat covers
+      // the same ground more slowly.
+    }
+  }
+
+  return {
+    userId: null,
+    status: "off",
+    direction: null,
+    dirty: false,
+    revision: 0,
+    syncedAt: null,
+    lastWriter: null,
+    auto: true,
+    error: null,
+    conflict: null,
+
+    attach: async (userId) => {
+      if (get().userId === userId && get().status !== "off") return;
+
+      const local = SyncManager.readState();
+      set({
+        userId,
+        status: "idle",
+        revision: local.revision,
+        syncedAt: local.syncedAt,
+        auto: local.auto,
+        error: null,
+        conflict: null,
+      });
+
+      installChangeWatchers();
+      installLifecycleListeners();
+      void subscribeRealtime(userId);
+
+      if (!heartbeat) {
+        heartbeat = setInterval(() => {
+          const s = get();
+          if (!s.userId || !s.auto || s.status === "conflict") return;
+          void serialize(() => (s.dirty ? performPush(false) : s.syncNow()));
+        }, HEARTBEAT_MS);
+      }
+
+      await serialize(() => get().syncNow());
+    },
+
+    detach: () => {
+      if (realtimeUnsub) {
+        realtimeUnsub();
+        realtimeUnsub = null;
+      }
+      if (heartbeat) {
+        clearInterval(heartbeat);
+        heartbeat = null;
+      }
+      if (debounceTimer) {
+        clearTimeout(debounceTimer);
+        debounceTimer = null;
+      }
+      SyncManager.clearState();
+      set({
+        userId: null,
+        status: "off",
+        direction: null,
+        dirty: false,
+        revision: 0,
+        syncedAt: null,
+        lastWriter: null,
+        error: null,
+        conflict: null,
+      });
+    },
+
+    markDirty: () => {
+      if (!get().userId || applying) return;
+      set({ dirty: true });
+      schedulePush();
+    },
+
+    syncNow: async () => {
+      const { userId } = get();
+      if (!userId) return;
+
+      set({ status: "busy", error: null });
+      try {
+        const localState = SyncManager.readState();
+        const head = await SyncManager.fetchHead(userId);
+
+        // Never synced from anywhere: this device seeds the account.
+        if (!head) {
+          await performPush(true);
+          return;
+        }
+
+        set({ lastWriter: head.deviceLabel || null });
+
+        // First sync on this device against an account that already has data.
+        if (localState.revision === 0) {
+          await raiseConflictOrAdopt(userId, head.id, true);
+          return;
+        }
+
+        if (head.revision > localState.revision) {
+          await raiseConflictOrAdopt(userId, head.id);
+          return;
+        }
+
+        if (get().dirty || head.revision < localState.revision) {
+          await performPush(false);
+          return;
+        }
+
+        set({ status: "idle", direction: null });
+      } catch (error) {
+        set({ status: "error", direction: null, error: messageFor(error) });
+      }
+    },
+
+    forcePush: async () => {
+      await serialize(() => performPush(true));
+    },
+
+    forcePull: async () => {
+      await serialize(() => performPull());
+    },
+
+    resolveConflict: async (keep) => {
+      const conflict = get().conflict;
+      if (!conflict) return;
+
+      if (keep === "cloud") {
+        set({ conflict: null });
+        await serialize(() =>
+          performPull(
+            conflict.remotePayload,
+            conflict.remoteRevision,
+            conflict.remoteRecordId,
+          ),
+        );
+        return;
+      }
+
+      // Keeping this device: adopt the cloud's revision as the baseline so the
+      // push lands on top of it rather than tripping the same conflict again.
+      SyncManager.writeState({
+        revision: conflict.remoteRevision,
+        recordId: conflict.remoteRecordId,
+      });
+      set({ conflict: null, revision: conflict.remoteRevision });
+      await serialize(() => performPush(true));
+    },
+
+    dismissConflict: () => {
+      set({ conflict: null, status: "idle" });
+    },
+
+    setAuto: (auto) => {
+      SyncManager.writeState({ auto });
+      set({ auto });
+      if (auto) void serialize(() => get().syncNow());
+    },
+
+    deleteCloudCopy: async () => {
+      const state = SyncManager.readState();
+      const { userId } = get();
+      if (!userId) return;
+      const head = state.recordId
+        ? { id: state.recordId }
+        : await SyncManager.fetchHead(userId);
+      if (!head) return;
+      await SyncManager.wipe(head.id);
+      SyncManager.writeState({ revision: 0, syncedAt: null, recordId: null });
+      set({ revision: 0, syncedAt: null, dirty: true, status: "idle" });
+    },
+  };
+});

--- a/lib/SaveManager.ts
+++ b/lib/SaveManager.ts
@@ -41,6 +41,49 @@
  */
 
 import db, { type ExcalidrawSceneData, type AIConfig, QuickLink } from "./db";
+import { PB_AUTH_STORAGE_KEY } from "./pocketbase";
+
+/**
+ * localStorage keys that survive an import.
+ *
+ * Restoring a backup replaces localStorage wholesale, which would otherwise
+ * sign the user out of the account they are restoring from and reset the sync
+ * bookkeeping mid-operation. These keys belong to the device and the session,
+ * not to the data being restored.
+ */
+const PROTECTED_LOCAL_KEYS: readonly string[] = [
+  PB_AUTH_STORAGE_KEY,
+  "bitfocus.sync.state",
+  "bitfocus.sync.device",
+];
+
+/** True when a localStorage key belongs to the device rather than the backup. */
+export function isProtectedLocalKey(key: string): boolean {
+  return PROTECTED_LOCAL_KEYS.includes(key);
+}
+
+/**
+ * Replace localStorage with the imported contents, keeping device-owned keys.
+ *
+ * @param entries - Key/value pairs from the backup.
+ */
+function restoreLocalStorage(entries: Record<string, string>): void {
+  const preserved = new Map<string, string>();
+  for (const key of PROTECTED_LOCAL_KEYS) {
+    const value = localStorage.getItem(key);
+    if (value !== null) preserved.set(key, value);
+  }
+
+  localStorage.clear();
+
+  for (const [key, value] of Object.entries(entries)) {
+    if (isProtectedLocalKey(key)) continue;
+    localStorage.setItem(key, value);
+  }
+  for (const [key, value] of preserved) {
+    localStorage.setItem(key, value);
+  }
+}
 
 /**
  * Enhanced Exported Data Structure Interface
@@ -153,8 +196,18 @@ type ExportedData = {
     }[];
     /** AI config */
     aiConfig: AIConfig[];
+    /** Calendar timeblock records */
+    timeblocks?: {
+      id?: number;
+      tag: string;
+      startTime: string; // Serialized as ISO string
+      endTime: string; // Serialized as ISO string
+      title?: string;
+    }[];
   };
 };
+
+export type { ExportedData };
 
 /**
  * Enhanced Save Manager Class
@@ -260,13 +313,21 @@ class SaveManager {
           updatedAt: c.updatedAt.toISOString(),
         })),
         aiConfig: await db.aiConfig.toArray(),
+        // Serialize calendar timeblocks with date conversion
+        timeblocks: (await db.timeblocks.toArray()).map((t) => ({
+          ...t,
+          startTime: t.startTime.toISOString(),
+          endTime: t.endTime.toISOString(),
+        })),
       },
     };
 
     // Export localStorage contents
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i);
-      if (key) {
+      // Session tokens and sync bookkeeping are device-owned: they never leave
+      // this browser, in a backup file or a cloud snapshot.
+      if (key && !isProtectedLocalKey(key)) {
         data.localStorage[key] = localStorage.getItem(key) || "";
       }
     }
@@ -393,6 +454,13 @@ class SaveManager {
 
     const aiConfig = data.indexedDB.aiConfig || [];
 
+    // Deserialize timeblocks with date conversion
+    const timeblocks = (data.indexedDB.timeblocks || []).map((t) => ({
+      ...t,
+      startTime: new Date(t.startTime),
+      endTime: new Date(t.endTime),
+    }));
+
     // Atomic database import operation including all tables
     await db.transaction(
       "rw",
@@ -408,6 +476,7 @@ class SaveManager {
         db.excalidraw,
         db.aiChats,
         db.aiConfig,
+        db.timeblocks,
       ],
       async () => {
         // Clear existing data from all tables
@@ -422,6 +491,7 @@ class SaveManager {
         await db.excalidraw.clear();
         await db.aiChats.clear();
         await db.aiConfig.clear();
+        await db.timeblocks.clear();
 
         // Import new data with project management support
         await db.configuration.bulkAdd(configuration);
@@ -453,14 +523,14 @@ class SaveManager {
         if (aiConfig.length > 0) {
           await db.aiConfig.bulkAdd(aiConfig);
         }
+        if (timeblocks.length > 0) {
+          await db.timeblocks.bulkAdd(timeblocks);
+        }
       },
     );
 
-    // Restore localStorage contents
-    localStorage.clear();
-    for (const [key, value] of Object.entries(data.localStorage)) {
-      localStorage.setItem(key, value);
-    }
+    // Restore localStorage contents, keeping the session and sync bookkeeping
+    restoreLocalStorage(data.localStorage);
   }
 
   /**
@@ -527,12 +597,20 @@ class SaveManager {
           updatedAt: c.updatedAt.toISOString(),
         })),
         aiConfig: await db.aiConfig.toArray(),
+        // Serialize calendar timeblocks with date conversion
+        timeblocks: (await db.timeblocks.toArray()).map((t) => ({
+          ...t,
+          startTime: t.startTime.toISOString(),
+          endTime: t.endTime.toISOString(),
+        })),
       },
     };
 
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i);
-      if (key) {
+      // Session tokens and sync bookkeeping are device-owned: they never leave
+      // this browser, in a backup file or a cloud snapshot.
+      if (key && !isProtectedLocalKey(key)) {
         data.localStorage[key] = localStorage.getItem(key) || "";
       }
     }
@@ -613,6 +691,13 @@ class SaveManager {
 
     const aiConfig = data.indexedDB.aiConfig || [];
 
+    // Deserialize timeblocks with date conversion
+    const timeblocks = (data.indexedDB.timeblocks || []).map((t) => ({
+      ...t,
+      startTime: new Date(t.startTime),
+      endTime: new Date(t.endTime),
+    }));
+
     await db.transaction(
       "rw",
       [
@@ -627,6 +712,7 @@ class SaveManager {
         db.excalidraw,
         db.aiChats,
         db.aiConfig,
+        db.timeblocks,
       ],
       async () => {
         await db.configuration.clear();
@@ -640,6 +726,7 @@ class SaveManager {
         await db.excalidraw.clear();
         await db.aiChats.clear();
         await db.aiConfig.clear();
+        await db.timeblocks.clear();
 
         await db.configuration.bulkAdd(configuration);
         await db.focus.bulkAdd(focus);
@@ -669,13 +756,13 @@ class SaveManager {
         if (aiConfig.length > 0) {
           await db.aiConfig.bulkAdd(aiConfig);
         }
+        if (timeblocks.length > 0) {
+          await db.timeblocks.bulkAdd(timeblocks);
+        }
       },
     );
 
-    localStorage.clear();
-    for (const [key, value] of Object.entries(data.localStorage)) {
-      localStorage.setItem(key, value);
-    }
+    restoreLocalStorage(data.localStorage);
   }
 }
 

--- a/lib/SyncManager.ts
+++ b/lib/SyncManager.ts
@@ -1,0 +1,381 @@
+/**
+ * Sync Manager - Cloud Snapshot Read/Write Primitives
+ *
+ * The data layer under account sync. BIT Focus stores a modest amount of data,
+ * so rather than mirroring every table into its own remote collection, the
+ * whole application state travels as a single JSON snapshot in one
+ * `focus_sync` record per user. One record means one revision number, which
+ * means conflicts are a comparison rather than a merge.
+ *
+ * This module is deliberately free of React and of policy: it reads, writes,
+ * summarizes, and remembers where the device last left off. When to do any of
+ * that is decided by the sync engine in `hooks/useSync.ts`.
+ *
+ * @fileoverview Snapshot capture, restore, remote I/O, and device bookkeeping.
+ * @author BIT Focus Development Team
+ * @since v0.19.0
+ */
+
+import SaveManager, { type ExportedData } from "./SaveManager";
+import { pb, SYNC_COLLECTION } from "./pocketbase";
+import type { RecordModel } from "pocketbase";
+
+/** localStorage key holding this device's stable identity. */
+const DEVICE_KEY = "bitfocus.sync.device";
+
+/** localStorage key holding where this device last left off. */
+const STATE_KEY = "bitfocus.sync.state";
+
+/** The application snapshot shipped to and from the backend. */
+export type SyncPayload = ExportedData;
+
+/** A `focus_sync` record as returned by PocketBase. */
+export interface SyncRecord extends RecordModel {
+  user: string;
+  payload: SyncPayload;
+  revision: number;
+  device: string;
+  deviceLabel: string;
+  appVersion: string;
+  updated: string;
+}
+
+/** Lightweight remote head, fetched without pulling the payload down. */
+export interface RemoteHead {
+  id: string;
+  revision: number;
+  updated: string;
+  device: string;
+  deviceLabel: string;
+}
+
+/** Where this device believes it left off. Persisted across reloads. */
+export interface LocalSyncState {
+  /** Revision this device last successfully pushed or pulled. */
+  revision: number;
+  /** ISO timestamp of that last successful sync, or null if never. */
+  syncedAt: string | null;
+  /** Cached remote record id, so pushes skip a lookup. */
+  recordId: string | null;
+  /** Whether background sync is switched on for this device. */
+  auto: boolean;
+}
+
+const DEFAULT_STATE: LocalSyncState = {
+  revision: 0,
+  syncedAt: null,
+  recordId: null,
+  auto: true,
+};
+
+/** Counts describing a snapshot, used to make a conflict choice informed. */
+export interface SnapshotSummary {
+  focusSessions: number;
+  projects: number;
+  notes: number;
+  drawings: number;
+  chats: number;
+  timeblocks: number;
+  /** Approximate serialized size in bytes. */
+  bytes: number;
+  /** Most recent activity found anywhere in the snapshot, if any. */
+  lastActivity: Date | null;
+}
+
+/**
+ * Describe the current browser in a way a person recognizes in a device list.
+ *
+ * Deliberately coarse — "Chrome on Windows" is enough to tell two devices
+ * apart, and nothing finer is needed.
+ */
+function detectDeviceLabel(): string {
+  if (typeof navigator === "undefined") return "Unknown device";
+  const ua = navigator.userAgent;
+
+  const browser = /Edg\//.test(ua)
+    ? "Edge"
+    : /OPR\//.test(ua)
+      ? "Opera"
+      : /Firefox\//.test(ua)
+        ? "Firefox"
+        : /Chrome\//.test(ua)
+          ? "Chrome"
+          : /Safari\//.test(ua)
+            ? "Safari"
+            : "Browser";
+
+  const os = /Windows/.test(ua)
+    ? "Windows"
+    : /Android/.test(ua)
+      ? "Android"
+      : /iPhone|iPad|iPod/.test(ua)
+        ? "iOS"
+        : /Mac OS X/.test(ua)
+          ? "macOS"
+          : /Linux/.test(ua)
+            ? "Linux"
+            : "this device";
+
+  return `${browser} on ${os}`;
+}
+
+class SyncManager {
+  // ── Device identity ──────────────────────────────────────────────────────
+
+  /**
+   * Stable identifier for this browser profile.
+   *
+   * Generated once and kept in localStorage. It exists so a device can tell
+   * "the cloud moved because of me" from "the cloud moved because of my
+   * phone", and never leaves the user's own records.
+   */
+  static deviceId(): string {
+    if (typeof window === "undefined") return "server";
+    try {
+      const raw = localStorage.getItem(DEVICE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as { id?: string };
+        if (parsed.id) return parsed.id;
+      }
+    } catch {
+      // Corrupt entry: fall through and mint a fresh identity.
+    }
+    const id =
+      typeof crypto !== "undefined" && "randomUUID" in crypto
+        ? crypto.randomUUID().slice(0, 24)
+        : Math.random().toString(36).slice(2, 14);
+    localStorage.setItem(
+      DEVICE_KEY,
+      JSON.stringify({ id, label: detectDeviceLabel() }),
+    );
+    return id;
+  }
+
+  /** Human-readable name for this device. */
+  static deviceLabel(): string {
+    if (typeof window === "undefined") return "Server";
+    try {
+      const raw = localStorage.getItem(DEVICE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as { label?: string };
+        if (parsed.label) return parsed.label;
+      }
+    } catch {
+      // Fall through to a freshly detected label.
+    }
+    return detectDeviceLabel();
+  }
+
+  // ── Local bookkeeping ────────────────────────────────────────────────────
+
+  /** Read this device's sync position, falling back to defaults. */
+  static readState(): LocalSyncState {
+    if (typeof window === "undefined") return { ...DEFAULT_STATE };
+    try {
+      const raw = localStorage.getItem(STATE_KEY);
+      if (!raw) return { ...DEFAULT_STATE };
+      return { ...DEFAULT_STATE, ...(JSON.parse(raw) as Partial<LocalSyncState>) };
+    } catch {
+      return { ...DEFAULT_STATE };
+    }
+  }
+
+  /** Merge a patch into this device's sync position. */
+  static writeState(patch: Partial<LocalSyncState>): LocalSyncState {
+    const next = { ...SyncManager.readState(), ...patch };
+    if (typeof window !== "undefined") {
+      localStorage.setItem(STATE_KEY, JSON.stringify(next));
+    }
+    return next;
+  }
+
+  /** Forget this device's sync position, e.g. after signing out. */
+  static clearState(): void {
+    if (typeof window !== "undefined") localStorage.removeItem(STATE_KEY);
+  }
+
+  // ── Snapshot ─────────────────────────────────────────────────────────────
+
+  /** Capture the full application state as a portable snapshot. */
+  static async snapshot(): Promise<SyncPayload> {
+    return SaveManager.exportJSON();
+  }
+
+  /** Replace all local application state with a snapshot. */
+  static async apply(payload: SyncPayload): Promise<void> {
+    await SaveManager.importJSON(payload);
+  }
+
+  /**
+   * Summarize a snapshot for display.
+   *
+   * Used by the conflict dialog, where the choice between two versions is only
+   * meaningful if the person can see what each one holds.
+   *
+   * @param payload - Snapshot to describe, from either side of a conflict.
+   */
+  static summarize(payload: SyncPayload | null | undefined): SnapshotSummary {
+    const empty: SnapshotSummary = {
+      focusSessions: 0,
+      projects: 0,
+      notes: 0,
+      drawings: 0,
+      chats: 0,
+      timeblocks: 0,
+      bytes: 0,
+      lastActivity: null,
+    };
+    if (!payload?.indexedDB) return empty;
+
+    const idb = payload.indexedDB;
+    const times: number[] = [];
+
+    // Newest timestamp anywhere decides how recently this snapshot was lived
+    // in — the one fact that tells "my current data" from "a stale copy".
+    const note = (value: string | undefined) => {
+      if (!value) return;
+      const t = Date.parse(value);
+      if (!Number.isNaN(t)) times.push(t);
+    };
+
+    for (const f of idb.focus ?? []) note(f.endTime);
+    for (const n of idb.notes ?? []) note(n.updatedAt);
+    for (const p of idb.projects ?? []) note(p.updatedAt);
+    for (const m of idb.milestones ?? []) note(m.updatedAt);
+    for (const i of idb.issues ?? []) note(i.updatedAt);
+    for (const e of idb.excalidraw ?? []) note(e.updatedAt);
+    for (const c of idb.aiChats ?? []) note(c.updatedAt);
+    for (const t of idb.timeblocks ?? []) note(t.endTime);
+
+    let bytes = 0;
+    try {
+      bytes = JSON.stringify(payload).length;
+    } catch {
+      bytes = 0;
+    }
+
+    return {
+      focusSessions: idb.focus?.length ?? 0,
+      projects: idb.projects?.length ?? 0,
+      notes: idb.notes?.length ?? 0,
+      drawings: idb.excalidraw?.length ?? 0,
+      chats: idb.aiChats?.length ?? 0,
+      timeblocks: idb.timeblocks?.length ?? 0,
+      bytes,
+      lastActivity: times.length ? new Date(Math.max(...times)) : null,
+    };
+  }
+
+  /**
+   * Whether a snapshot is effectively blank.
+   *
+   * A device with nothing worth keeping can adopt the cloud copy without
+   * asking, which is what makes signing in on a second device a single step.
+   */
+  static isEmpty(payload: SyncPayload | null | undefined): boolean {
+    const s = SyncManager.summarize(payload);
+    return (
+      s.focusSessions === 0 &&
+      s.projects === 0 &&
+      s.notes === 0 &&
+      s.drawings === 0 &&
+      s.chats === 0 &&
+      s.timeblocks === 0
+    );
+  }
+
+  // ── Remote I/O ───────────────────────────────────────────────────────────
+
+  /**
+   * Read the remote revision without downloading the payload.
+   *
+   * @param userId - Owner of the snapshot.
+   * @returns The remote head, or null when the account has never synced.
+   */
+  static async fetchHead(userId: string): Promise<RemoteHead | null> {
+    try {
+      const record = await pb
+        .collection(SYNC_COLLECTION)
+        .getFirstListItem<SyncRecord>(`user = "${userId}"`, {
+          fields: "id,revision,updated,device,deviceLabel",
+        });
+      return {
+        id: record.id,
+        revision: record.revision ?? 0,
+        updated: record.updated,
+        device: record.device ?? "",
+        deviceLabel: record.deviceLabel ?? "",
+      };
+    } catch (error) {
+      if (isNotFound(error)) return null;
+      throw error;
+    }
+  }
+
+  /**
+   * Download the full remote snapshot.
+   *
+   * @param userId - Owner of the snapshot.
+   * @returns The record, or null when the account has never synced.
+   */
+  static async fetchRecord(userId: string): Promise<SyncRecord | null> {
+    try {
+      return await pb
+        .collection(SYNC_COLLECTION)
+        .getFirstListItem<SyncRecord>(`user = "${userId}"`);
+    } catch (error) {
+      if (isNotFound(error)) return null;
+      throw error;
+    }
+  }
+
+  /**
+   * Write a snapshot to the backend, creating the record on first sync.
+   *
+   * @param userId - Owner of the snapshot.
+   * @param payload - Snapshot to store.
+   * @param revision - Revision number to stamp on the write.
+   * @param recordId - Known record id, when the caller already has one.
+   * @param appVersion - App version that produced the snapshot.
+   */
+  static async write(
+    userId: string,
+    payload: SyncPayload,
+    revision: number,
+    recordId: string | null,
+    appVersion: string,
+  ): Promise<SyncRecord> {
+    const body = {
+      user: userId,
+      payload,
+      revision,
+      device: SyncManager.deviceId(),
+      deviceLabel: SyncManager.deviceLabel(),
+      appVersion,
+    };
+
+    if (recordId) {
+      return await pb
+        .collection(SYNC_COLLECTION)
+        .update<SyncRecord>(recordId, body);
+    }
+    return await pb.collection(SYNC_COLLECTION).create<SyncRecord>(body);
+  }
+
+  /** Delete the cloud snapshot, leaving the account and local data intact. */
+  static async wipe(recordId: string): Promise<void> {
+    await pb.collection(SYNC_COLLECTION).delete(recordId);
+  }
+}
+
+/** PocketBase reports "no matching record" as a 404. */
+function isNotFound(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    (error as { status?: number }).status === 404
+  );
+}
+
+export default SyncManager;

--- a/lib/pocketbase.ts
+++ b/lib/pocketbase.ts
@@ -1,0 +1,100 @@
+/**
+ * PocketBase Client - Shared Backend Connection
+ *
+ * BIT Focus is local-first: every feature works with no account at all. When a
+ * user *chooses* to connect an account, this module is the single door to the
+ * backend that makes their data follow them between devices.
+ *
+ * The backend is a PocketBase instance shared across BrazeApps. The `users`
+ * auth collection is deliberately unified — one identity for every app — while
+ * everything belonging to this app is namespaced with a `focus_` prefix.
+ *
+ * Authentication is OAuth2-only (Google, Discord, GitHub). There is no
+ * email/password path: the `users` collection has password auth disabled
+ * server-side, so the only way in is a provider the user already trusts.
+ *
+ * @fileoverview PocketBase singleton, collection names, and shared auth types.
+ * @author BIT Focus Development Team
+ * @since v0.19.0
+ */
+
+import PocketBase, { type RecordModel } from "pocketbase";
+
+/**
+ * Backend origin. Overridable per-environment; falls back to the shared
+ * BrazeApps instance so a checkout with no `.env` still works.
+ */
+export const POCKETBASE_URL =
+  process.env.NEXT_PUBLIC_POCKETBASE_URL ?? "https://brazeapps-db.uziraze.com";
+
+/** Unified identity collection, shared with other BrazeApps products. */
+export const USERS_COLLECTION = "users";
+
+/** This app's snapshot collection. One record per user. */
+export const SYNC_COLLECTION = "focus_sync";
+
+/**
+ * localStorage key the PocketBase SDK uses for its auth store.
+ *
+ * Exported because our own import/restore paths must never clear it — wiping
+ * it mid-restore would sign the user out of the very account they are
+ * restoring from.
+ */
+export const PB_AUTH_STORAGE_KEY = "pocketbase_auth";
+
+/** Singleton client. Recreated per module load; safe on the server (no window). */
+export const pb = new PocketBase(POCKETBASE_URL);
+
+// The SDK auto-cancels duplicate in-flight requests to the same endpoint. Sync
+// legitimately fires overlapping reads and writes, so opt out globally and
+// handle races ourselves in the sync engine.
+pb.autoCancellation(false);
+
+/**
+ * Authenticated User Record
+ *
+ * The subset of the shared `users` collection this app reads. Providers give us
+ * a name, an email, and a picture — that is all BIT Focus asks for.
+ */
+export interface AuthUser extends RecordModel {
+  /** Display name, mapped from the OAuth2 provider profile. */
+  name: string;
+  /** Primary email address from the provider. */
+  email: string;
+  /** Provider-hosted profile picture URL. */
+  avatarUrl: string;
+  /** Slug of the provider used most recently (e.g. `google`). */
+  provider: string;
+}
+
+/** OAuth2 providers this app renders sign-in buttons for, in display order. */
+export const SUPPORTED_PROVIDERS = ["google", "discord", "github"] as const;
+
+export type ProviderName = (typeof SUPPORTED_PROVIDERS)[number];
+
+/** Human-readable provider names for UI copy. */
+export const PROVIDER_LABELS: Record<string, string> = {
+  google: "Google",
+  discord: "Discord",
+  github: "GitHub",
+};
+
+/**
+ * Resolve Avatar URL
+ *
+ * Prefers the provider picture stored on the record. Falls back to the same
+ * DiceBear mark the app already uses for local-only profiles, so an account
+ * without a picture still gets a consistent avatar rather than a blank circle.
+ *
+ * @param user - Authenticated user record, or null when signed out.
+ * @param fallbackSeed - Seed used for the generated fallback avatar.
+ * @returns A URL suitable for an `<img src>`.
+ */
+export function resolveAvatarUrl(
+  user: AuthUser | null,
+  fallbackSeed: string,
+): string {
+  if (user?.avatarUrl) return user.avatarUrl;
+  const seed = user?.name || user?.email || fallbackSeed || "bit-focus";
+  return `https://api.dicebear.com/9.x/shapes/svg?seed=${encodeURIComponent(seed)}`;
+}

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "lucide-react": "^0.482.0",
     "next": "15.2.8",
     "next-themes": "^0.4.6",
+    "pocketbase": "^0.27.0",
     "react": "^19.0.0",
     "react-big-calendar": "^1.19.4",
     "react-day-picker": "^9.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      pocketbase:
+        specifier: ^0.27.0
+        version: 0.27.0
       react:
         specifier: ^19.0.0
         version: 19.1.0
@@ -4566,6 +4569,9 @@ packages:
 
   png-chunks-extract@1.0.0:
     resolution: {integrity: sha512-ZiVwF5EJ0DNZyzAqld8BP1qyJBaGOFaq9zl579qfbkcmOwWLLO4I9L8i2O4j3HkI6/35i0nKG2n+dZplxiT89Q==}
+
+  pocketbase@0.27.0:
+    resolution: {integrity: sha512-K5N6d93UP/BNMbMnlZ6BUfy9VPCIvLyqhJFOsNI8OsZwzvKWEAfyD36boi5K4ECIOl5HMlo0TzuaeGdKpMwizQ==}
 
   points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
@@ -10305,6 +10311,8 @@ snapshots:
   png-chunks-extract@1.0.0:
     dependencies:
       crc-32: 0.3.0
+
+  pocketbase@0.27.0: {}
 
   points-on-curve@0.2.0: {}
 


### PR DESCRIPTION
This pull request introduces a major new feature: opt-in accounts and cross-device sync, along with a comprehensive UI for managing account status, sign-in, and sync state. The update adds a full account system (Google, Discord, GitHub), two-way sync for all data, onboarding improvements, and new UI elements for account management and sync feedback throughout the app.

**Major new features:**

* Accounts and cross-device sync are now available, fully opt-in and local-first. Users can sign in with Google (coming soon), Discord, or GitHub, and all data (sessions, tags, projects, notes, etc.) syncs across devices. A new `/account` page provides sync status, ledger, manual controls, and account removal.

**UI/UX enhancements for accounts and sync:**

* Added new components:
  - `AccountAvatar` for unified avatar rendering, showing the user's provider profile picture with a fallback to the generated local avatar.
  - `AccountPanel` for a compact account and sync summary in the profile dropdown, including sign-in/out, sync status, and quick navigation.
  - `ConnectAccountDialog` and `ProviderButtons` for a clear, provider-driven sign-in dialog with live availability and no password creation. [[1]](diffhunk://#diff-b5d6a486507c39e75b7eae6095f3252e1fda0b05a9bdaa9f5d2fabb399e12f1cR1-R91) [[2]](diffhunk://#diff-435abd4a614a703479ba2fe42c76a53002c3a2ab45be29986e0ddc84611be17dR1-R128)
  - `SyncChip` and `SyncRail` for at-a-glance sync status in the Top Bar and a visual sync direction indicator.

* The sidebar profile button now displays the account avatar and name if signed in, with an updated popover showing the new account panel. [[1]](diffhunk://#diff-2f15395554f7bcb56a2b61e72d6d1126b6af506207c3eab43a9f631468bc325eR283) [[2]](diffhunk://#diff-2f15395554f7bcb56a2b61e72d6d1126b6af506207c3eab43a9f631468bc325eL298-R314) [[3]](diffhunk://#diff-2f15395554f7bcb56a2b61e72d6d1126b6af506207c3eab43a9f631468bc325eL336-R341)
* Sync runs during onboarding, so signing in on a fresh device restores data before setup.
* New page titles for `/account` and `/focus-table`.

**Styling and animation:**

* Added CSS for the "sync rail" animation, visually indicating upload/download direction and supporting reduced motion preferences.

**Security and data handling:**

* Session tokens are never written to exports or cloud, and all synced collections are owner-scoped for security. Importing a backup no longer signs out the user.

These changes lay the groundwork for robust, user-friendly account and sync support, making it easy to work across devices while keeping local-first principles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional account sign-in with Google, Discord, or GitHub.
  * Added cross-device cloud sync with status indicators, manual controls, auto-sync, and conflict resolution.
  * Added an Account page for managing sync, sessions, cloud data, and account deletion.
  * Added account and sync steps to onboarding, plus improved profile controls and avatars.
  * Calendar timeblocks are now included in backup and restore operations.

* **Bug Fixes**
  * Restoring backups now preserves device settings and no longer signs users out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->